### PR TITLE
[AWARD-1110] - Fixed download button not working for New/Changed Export screens

### DIFF
--- a/src/SFA.DAS.AODP.Data/Entities/Qualification/ChangedQualificationExport.cs
+++ b/src/SFA.DAS.AODP.Data/Entities/Qualification/ChangedQualificationExport.cs
@@ -42,7 +42,7 @@
         public bool? NineteenPlus { get; set; }
 
         // Funding Details (Placeholders)
-        public bool? FundedInEngland { get; set; }              // Placeholder
+        public bool? IntentionToSeekFundingInEngland { get; set; }              // Placeholder
         public bool? FundingInWales { get; set; }                // Placeholder
         public bool? FundingInNorthernIreland { get; set; }      // Placeholder
 

--- a/src/SFA.DAS.AODP.Data/Entities/Qualification/NewQualificationExport.cs
+++ b/src/SFA.DAS.AODP.Data/Entities/Qualification/NewQualificationExport.cs
@@ -46,7 +46,7 @@ namespace SFA.DAS.AODP.Data.Entities.Qualification
         public bool? NineteenPlus { get; set; }
 
         // Funding Details (Placeholders)
-        public bool? FundedInEngland { get; set; }              
+        public bool? IntentionToSeekFundingInEngland { get; set; }              
         public bool? FundingInWales { get; set; }                // Placeholder
         public bool? FundingInNorthernIreland { get; set; }      // Placeholder
 


### PR DESCRIPTION
-  [AWARD-1110] - Due to the removal of the IntentionToSeekFundingInEngland field last year the DTOs representing the New/Changed qualification views were now mismatched i.e. a column being returned wasnt mapped, this PR fixes that by re-introducing the field as its been introduced into the wider system

[AWARD-1110]: https://skillsfundingagency.atlassian.net/browse/AWARD-1110?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ