### PR TITLE
[AWARD-1240] - Fix issues around request size limits and perf issues

### DIFF
--- a/src/SFA.DAS.AODP.Api.Tests/Controllers/Rollover/RolloverControllerTests.cs
+++ b/src/SFA.DAS.AODP.Api.Tests/Controllers/Rollover/RolloverControllerTests.cs
@@ -11,6 +11,9 @@ using SFA.DAS.AODP.Application.Commands.Rollover;
 using SFA.DAS.AODP.Application.Exceptions;
 using SFA.DAS.AODP.Application.Queries.Rollover;
 using SFA.DAS.AODP.Models.Rollover;
+using Shouldly;
+using System.Text;
+using System.Text.Json;
 
 namespace SFA.DAS.AODP.Api.UnitTests.Controllers.Rollover;
 
@@ -305,7 +308,7 @@ public class RolloverControllerTests : UnitTest
         _mediatorMock.Setup(m => m.Send(It.IsAny<ValidateRolloverExtensionCommand>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(mediatorResponse);
 
-        var result = await _controller.ValidateRolloverExtension(command);
+        var result = await _controller.ValidateRolloverExtension(CreateJsonFile(command), CancellationToken);
 
         var ok = Assert.IsType<OkObjectResult>(result);
         var payload = Assert.IsType<ValidateRolloverExtensionCommandResponse>(ok.Value);
@@ -338,7 +341,7 @@ public class RolloverControllerTests : UnitTest
         _mediatorMock.Setup(m => m.Send(It.IsAny<ValidateRolloverExtensionCommand>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(mediatorResponse);
 
-        var result = await _controller.ValidateRolloverExtension(command);
+        var result = await _controller.ValidateRolloverExtension(CreateJsonFile(command), CancellationToken);
 
         var ok = Assert.IsType<OkObjectResult>(result);
         var payload = Assert.IsType<ValidateRolloverExtensionCommandResponse>(ok.Value);
@@ -363,7 +366,7 @@ public class RolloverControllerTests : UnitTest
         _mediatorMock.Setup(m => m.Send(It.IsAny<ValidateRolloverExtensionCommand>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(mediatorResponse);
 
-        var result = await _controller.ValidateRolloverExtension(command);
+        var result = await _controller.ValidateRolloverExtension(CreateJsonFile(command), CancellationToken);
 
         var status = Assert.IsType<StatusCodeResult>(result);
         Assert.Equal(StatusCodes.Status500InternalServerError, status.StatusCode);
@@ -389,7 +392,7 @@ public class RolloverControllerTests : UnitTest
             .Setup(m => m.Send(It.IsAny<SubmitRolloverExtensionCommand>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(mediatorResponse);
 
-        var result = await _controller.SubmitRolloverExtension(command);
+        var result = await _controller.SubmitRolloverExtension(CreateJsonFile(command), CancellationToken);
 
         var ok = Assert.IsType<OkObjectResult>(result);
         var payload = Assert.IsType<SubmitRolloverExtensionCommandResponse>(ok.Value);
@@ -412,10 +415,46 @@ public class RolloverControllerTests : UnitTest
             .Setup(m => m.Send(It.IsAny<SubmitRolloverExtensionCommand>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(mediatorResponse);
 
-        var result = await _controller.SubmitRolloverExtension(command);
+        var result = await _controller.SubmitRolloverExtension(CreateJsonFile(command), CancellationToken);
 
         var status = Assert.IsType<StatusCodeResult>(result);
         Assert.Equal(StatusCodes.Status500InternalServerError, status.StatusCode);
+    }
+
+    [Fact]
+    public async Task ValidateRolloverExtension_WhenJsonIsInvalid_ReturnsBadRequest()
+    {
+        // Arrange
+        var payload = CreateRawFile("{ invalid json");
+
+        // Act
+        var result = await _controller.ValidateRolloverExtension(payload, CancellationToken);
+
+        // Assert
+        result.ShouldBeOfType<BadRequestObjectResult>();
+        _mediatorMock.Verify(
+            mediator => mediator.Send(
+                It.IsAny<ValidateRolloverExtensionCommand>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task SubmitRolloverExtension_WhenJsonFileIsEmpty_ReturnsBadRequest()
+    {
+        // Arrange
+        var payload = CreateRawFile(string.Empty);
+
+        // Act
+        var result = await _controller.SubmitRolloverExtension(payload, CancellationToken);
+
+        // Assert
+        result.ShouldBeOfType<BadRequestObjectResult>();
+        _mediatorMock.Verify(
+            mediator => mediator.Send(
+                It.IsAny<SubmitRolloverExtensionCommand>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
     }
 
     [Fact]
@@ -475,5 +514,20 @@ public class RolloverControllerTests : UnitTest
 
         var status = Assert.IsType<StatusCodeResult>(result);
         Assert.Equal(500, status.StatusCode);
+    }
+
+    private static IFormFile CreateJsonFile<T>(T value)
+    {
+        return CreateRawFile(JsonSerializer.Serialize(value));
+    }
+
+    private static IFormFile CreateRawFile(string value)
+    {
+        var stream = new MemoryStream(Encoding.UTF8.GetBytes(value));
+        return new FormFile(stream, 0, stream.Length, "payload", "payload.json")
+        {
+            Headers = new HeaderDictionary(),
+            ContentType = "application/json"
+        };
     }
 }

--- a/src/SFA.DAS.AODP.Api/Controllers/Rollover/RolloverController.cs
+++ b/src/SFA.DAS.AODP.Api/Controllers/Rollover/RolloverController.cs
@@ -83,9 +83,11 @@ public class RolloverController : BaseController
     }
 
     [HttpPost("validaterolloverextension")]
+    [Consumes("multipart/form-data")]
     [ProducesResponseType(typeof(ValidateRolloverExtensionCommandResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public async Task<IActionResult> ValidateRolloverExtension(ValidateRolloverExtensionCommand validateRolloverExtensionCommand)
+    public async Task<IActionResult> ValidateRolloverExtension(
+        [FromForm] ValidateRolloverExtensionCommand validateRolloverExtensionCommand)
     {
         if (!ModelState.IsValid)
         {
@@ -96,9 +98,11 @@ public class RolloverController : BaseController
     }
 
     [HttpPost("submitrolloverextension")]
+    [Consumes("multipart/form-data")]
     [ProducesResponseType(typeof(SubmitRolloverExtensionCommandResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public async Task<IActionResult> SubmitRolloverExtension(SubmitRolloverExtensionCommand submitRolloverExtensinCommand)
+    public async Task<IActionResult> SubmitRolloverExtension(
+        [FromForm] SubmitRolloverExtensionCommand submitRolloverExtensinCommand)
     {
         return await SendRequestAsync(submitRolloverExtensinCommand);
     }

--- a/src/SFA.DAS.AODP.Api/Controllers/Rollover/RolloverController.cs
+++ b/src/SFA.DAS.AODP.Api/Controllers/Rollover/RolloverController.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Mvc;
 using SFA.DAS.AODP.Application.Commands.Rollover;
 using SFA.DAS.AODP.Application.Queries.Rollover;
 using SFA.DAS.AODP.Models.Rollover;
+using System.Text.Json;
 
 namespace SFA.DAS.AODP.Api.Controllers.Rollover;
 
@@ -85,26 +86,31 @@ public class RolloverController : BaseController
     [HttpPost("validaterolloverextension")]
     [Consumes("multipart/form-data")]
     [ProducesResponseType(typeof(ValidateRolloverExtensionCommandResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     public async Task<IActionResult> ValidateRolloverExtension(
-        [FromForm] ValidateRolloverExtensionCommand validateRolloverExtensionCommand)
+        [FromForm] IFormFile payload,
+        CancellationToken cancellationToken)
     {
-        if (!ModelState.IsValid)
-        {
-            return BadRequest(ModelState);
-        }
-
-        return await SendRequestAsync(validateRolloverExtensionCommand);
+        var command = await ReadCommand<ValidateRolloverExtensionCommand>(payload, cancellationToken);
+        return command is null
+            ? BadRequest("The JSON payload is missing or invalid.")
+            : await SendRequestAsync(command);
     }
 
     [HttpPost("submitrolloverextension")]
     [Consumes("multipart/form-data")]
     [ProducesResponseType(typeof(SubmitRolloverExtensionCommandResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     public async Task<IActionResult> SubmitRolloverExtension(
-        [FromForm] SubmitRolloverExtensionCommand submitRolloverExtensinCommand)
+        [FromForm] IFormFile payload,
+        CancellationToken cancellationToken)
     {
-        return await SendRequestAsync(submitRolloverExtensinCommand);
+        var command = await ReadCommand<SubmitRolloverExtensionCommand>(payload, cancellationToken);
+        return command is null
+            ? BadRequest("The JSON payload is missing or invalid.")
+            : await SendRequestAsync(command);
     }
 
     [HttpPost("querybuilder/awardingorganisations")]
@@ -147,6 +153,31 @@ public class RolloverController : BaseController
     public async Task<IActionResult> GetSectorSubjectAreasForRolloverQueryBuilder([FromBody] RolloverQueryBuilderSectorSubjectAreaRequest filters)
     {
         return await SendRequestAsync(new GetSectorSubjectAreasForRolloverQueryBuilderQuery(filters));
+    }
+
+    private static async Task<TCommand?> ReadCommand<TCommand>(
+        IFormFile payload,
+        CancellationToken cancellationToken)
+    {
+        if (payload is null ||
+            payload.Length == 0 ||
+            !payload.ContentType.StartsWith("application/json", StringComparison.OrdinalIgnoreCase))
+        {
+            return default;
+        }
+
+        try
+        {
+            await using var stream = payload.OpenReadStream();
+            return await JsonSerializer.DeserializeAsync<TCommand>(stream, new JsonSerializerOptions
+            {
+                PropertyNameCaseInsensitive = true
+            }, cancellationToken);
+        }
+        catch (JsonException)
+        {
+            return default;
+        }
     }
 
     [HttpGet("startsummary")]

--- a/src/SFA.DAS.AODP.Api/Controllers/Rollover/RolloverController.cs
+++ b/src/SFA.DAS.AODP.Api/Controllers/Rollover/RolloverController.cs
@@ -89,7 +89,7 @@ public class RolloverController : BaseController
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     public async Task<IActionResult> ValidateRolloverExtension(
-        [FromForm] IFormFile payload,
+        IFormFile payload,
         CancellationToken cancellationToken)
     {
         var command = await ReadCommand<ValidateRolloverExtensionCommand>(payload, cancellationToken);
@@ -104,7 +104,7 @@ public class RolloverController : BaseController
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     public async Task<IActionResult> SubmitRolloverExtension(
-        [FromForm] IFormFile payload,
+        IFormFile payload,
         CancellationToken cancellationToken)
     {
         var command = await ReadCommand<SubmitRolloverExtensionCommand>(payload, cancellationToken);

--- a/src/SFA.DAS.AODP.Api/Program.cs
+++ b/src/SFA.DAS.AODP.Api/Program.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.AspNetCore.Http.Features;
-using Microsoft.AspNetCore.Mvc.Authorization;
+﻿using Microsoft.AspNetCore.Mvc.Authorization;
 using SFA.DAS.AODP.Api.Extensions;
 using SFA.DAS.AODP.Application.Commands.FormBuilder.Forms;
 using SFA.DAS.AODP.Application.Queries.Qualifications;
@@ -32,12 +31,6 @@ public static class Program
             .AddHealthChecks();
 
         builder.Services.AddAuthentication(configuration);
-
-        builder.Services.Configure<FormOptions>(options =>
-        {
-            // Rollover submissions can contain 10,000 candidates with several fields each.
-            options.ValueCountLimit = 100_000;
-        });
 
         builder.Services.AddControllers(options =>
         {

--- a/src/SFA.DAS.AODP.Api/Program.cs
+++ b/src/SFA.DAS.AODP.Api/Program.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Mvc.Authorization;
+﻿using Microsoft.AspNetCore.Http.Features;
+using Microsoft.AspNetCore.Mvc.Authorization;
 using SFA.DAS.AODP.Api.Extensions;
 using SFA.DAS.AODP.Application.Commands.FormBuilder.Forms;
 using SFA.DAS.AODP.Application.Queries.Qualifications;
@@ -31,6 +32,12 @@ public static class Program
             .AddHealthChecks();
 
         builder.Services.AddAuthentication(configuration);
+
+        builder.Services.Configure<FormOptions>(options =>
+        {
+            // Rollover submissions can contain 10,000 candidates with several fields each.
+            options.ValueCountLimit = 100_000;
+        });
 
         builder.Services.AddControllers(options =>
         {

--- a/src/SFA.DAS.AODP.Api/appsettings.json
+++ b/src/SFA.DAS.AODP.Api/appsettings.json
@@ -2,7 +2,20 @@
   "Logging": {
     "LogLevel": {
       "Default": "Warning",
-      "Microsoft.EntityFrameworkCore.Database.Command": "Warning"
+      "Microsoft.EntityFrameworkCore.Database.Command": "Warning",
+      "SFA.DAS.AODP.Application.Commands.Rollover.SubmitRolloverExtensionCommandHandler": "Information",
+      "SFA.DAS.AODP.Application.Commands.Rollover.ValidateRolloverExtensionCommandHandler": "Information",
+      "SFA.DAS.AODP.Application.Services.FundingExtension.SubmitFundingExtensionService": "Information",
+      "SFA.DAS.AODP.Data.Repositories.FundingExtension.FundingExtensionPersistenceRepository": "Information"
+    },
+    "ApplicationInsights": {
+      "LogLevel": {
+        "Default": "Warning",
+        "SFA.DAS.AODP.Application.Commands.Rollover.SubmitRolloverExtensionCommandHandler": "Information",
+        "SFA.DAS.AODP.Application.Commands.Rollover.ValidateRolloverExtensionCommandHandler": "Information",
+        "SFA.DAS.AODP.Application.Services.FundingExtension.SubmitFundingExtensionService": "Information",
+        "SFA.DAS.AODP.Data.Repositories.FundingExtension.FundingExtensionPersistenceRepository": "Information"
+      }
     }
   },
   "ConfigurationStorageConnectionString": "UseDevelopmentStorage=true;",

--- a/src/SFA.DAS.AODP.Application.Tests/Commands/Rollover/CreateRolloverWorkflowRunCommandHandlerTests.cs
+++ b/src/SFA.DAS.AODP.Application.Tests/Commands/Rollover/CreateRolloverWorkflowRunCommandHandlerTests.cs
@@ -1,325 +1,283 @@
-﻿using AutoFixture;
-using AutoFixture.AutoMoq;
 using Moq;
 using SFA.DAS.AODP.Application.Commands.Rollover;
 using SFA.DAS.AODP.Application.Exceptions;
 using SFA.DAS.AODP.Data.Entities.Rollover;
+using SFA.DAS.AODP.Data.Entities.Rollover.Enums;
 using SFA.DAS.AODP.Data.Exceptions;
 using SFA.DAS.AODP.Data.Repositories.Rollover;
 using SFA.DAS.AODP.Models.Rollover;
+using Shouldly;
 
-namespace SFA.DAS.AODP.Application.UnitTests.Commands.Rollover
+namespace SFA.DAS.AODP.Application.UnitTests.Commands.Rollover;
+
+public class CreateRolloverWorkflowRunCommandHandlerTests : UnitTest
 {
-    public class CreateRolloverWorkflowRunCommandHandlerTests
+    private readonly Mock<IRolloverRepository> _repository = new();
+    private readonly CreateRolloverWorkflowRunCommandHandler _handler;
+
+    public CreateRolloverWorkflowRunCommandHandlerTests()
     {
-        private readonly IFixture _fixture;
-        private readonly Mock<IRolloverRepository> _repositoryMock;
-        private readonly CreateRolloverWorkflowRunCommandHandler _handler;
+        _handler = new CreateRolloverWorkflowRunCommandHandler(_repository.Object);
+    }
 
-        public CreateRolloverWorkflowRunCommandHandlerTests()
+    [Fact]
+    public async Task Handle_WhenCandidatesAreValid_AppliesP1ChecksAndCreatesWorkflowOnce()
+    {
+        // Arrange
+        var command = CreateCommand();
+        var candidates = CreateCandidates(command.RolloverCandidateIds, command.AcademicYear);
+        _repository
+            .Setup(x => x.GetRolloverCandidatesWithP1ChecksAsync(
+                It.Is<IReadOnlyCollection<RolloverCandidateP1CheckRequest>>(requests =>
+                    requests.Select(request => request.RolloverCandidateId)
+                        .SequenceEqual(command.RolloverCandidateIds)),
+                CancellationToken))
+            .ReturnsAsync(CreateCandidatesWithChecks(candidates, command));
+        _repository
+            .Setup(x => x.CreateRolloverWorkflowAsync(
+                It.IsAny<RolloverWorkflowRun>(),
+                It.IsAny<IReadOnlyCollection<RolloverWorkflowCandidate>>(),
+                It.IsAny<IReadOnlyCollection<RolloverWorkflowRunFundingOffer>>(),
+                CancellationToken))
+            .ReturnsAsync((
+                RolloverWorkflowRun workflowRun,
+                IReadOnlyCollection<RolloverWorkflowCandidate> _,
+                IReadOnlyCollection<RolloverWorkflowRunFundingOffer> _,
+                CancellationToken _) => workflowRun.Id);
+
+        // Act
+        var result = await _handler.Handle(command, CancellationToken);
+
+        // Assert
+        result.Success.ShouldBeTrue();
+        result.Value.ShouldNotBeNull();
+        result.Value.RolloverWorkflowRunId.ShouldNotBe(Guid.Empty);
+
+        _repository.Verify(x => x.CreateRolloverWorkflowAsync(
+            It.Is<RolloverWorkflowRun>(run =>
+                run.Id == result.Value.RolloverWorkflowRunId),
+            It.Is<IReadOnlyCollection<RolloverWorkflowCandidate>>(workflowCandidates =>
+                workflowCandidates.Count == candidates.Count &&
+                workflowCandidates.All(candidate => candidate.PassP1)),
+            It.Is<IReadOnlyCollection<RolloverWorkflowRunFundingOffer>>(fundingOffers =>
+                fundingOffers.Count == command.FundingOfferIds.Count),
+            CancellationToken), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_WhenCandidateListIsNull_ReturnsFailure()
+    {
+        // Arrange
+        var command = CreateCommand();
+        command.RolloverCandidateIds = null!;
+
+        // Act
+        var result = await _handler.Handle(command, CancellationToken);
+
+        // Assert
+        result.Success.ShouldBeFalse();
+        result.InnerException.ShouldBeOfType<InvalidOperationException>();
+    }
+
+    [Fact]
+    public async Task Handle_WhenCandidateListIsEmpty_ReturnsFailure()
+    {
+        // Arrange
+        var command = CreateCommand();
+        command.RolloverCandidateIds = [];
+
+        // Act
+        var result = await _handler.Handle(command, CancellationToken);
+
+        // Assert
+        result.Success.ShouldBeFalse();
+        result.InnerException.ShouldBeOfType<InvalidOperationException>();
+    }
+
+    [Fact]
+    public async Task Handle_WhenCandidateIsMissing_ReturnsFailureWithoutCreatingWorkflow()
+    {
+        // Arrange
+        var command = CreateCommand();
+        var candidates = CreateCandidates(
+            command.RolloverCandidateIds.Take(1),
+            command.AcademicYear);
+        _repository
+            .Setup(x => x.GetRolloverCandidatesWithP1ChecksAsync(
+                It.IsAny<IReadOnlyCollection<RolloverCandidateP1CheckRequest>>(),
+                CancellationToken))
+            .ReturnsAsync(CreateCandidatesWithChecks(candidates, command));
+
+        // Act
+        var result = await _handler.Handle(command, CancellationToken);
+
+        // Assert
+        result.Success.ShouldBeFalse();
+        result.InnerException.ShouldBeOfType<InvalidOperationException>();
+        _repository.Verify(x => x.CreateRolloverWorkflowAsync(
+            It.IsAny<RolloverWorkflowRun>(),
+            It.IsAny<IReadOnlyCollection<RolloverWorkflowCandidate>>(),
+            It.IsAny<IReadOnlyCollection<RolloverWorkflowRunFundingOffer>>(),
+            It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_WhenCandidateAndP1DataIsMissing_ReturnsFailureWithoutCreatingWorkflow()
+    {
+        // Arrange
+        var command = CreateCommand();
+        _repository
+            .Setup(x => x.GetRolloverCandidatesWithP1ChecksAsync(
+                It.IsAny<IReadOnlyCollection<RolloverCandidateP1CheckRequest>>(),
+                CancellationToken))
+            .ReturnsAsync([]);
+
+        // Act
+        var result = await _handler.Handle(command, CancellationToken);
+
+        // Assert
+        result.Success.ShouldBeFalse();
+        result.InnerException.ShouldBeOfType<InvalidOperationException>();
+        _repository.Verify(x => x.CreateRolloverWorkflowAsync(
+            It.IsAny<RolloverWorkflowRun>(),
+            It.IsAny<IReadOnlyCollection<RolloverWorkflowCandidate>>(),
+            It.IsAny<IReadOnlyCollection<RolloverWorkflowRunFundingOffer>>(),
+            It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_WhenAtomicCreateIsLocked_ReturnsLockedRecordException()
+    {
+        // Arrange
+        var command = CreateCommand();
+        SetupCandidatesAndChecks(command);
+        _repository
+            .Setup(x => x.CreateRolloverWorkflowAsync(
+                It.IsAny<RolloverWorkflowRun>(),
+                It.IsAny<IReadOnlyCollection<RolloverWorkflowCandidate>>(),
+                It.IsAny<IReadOnlyCollection<RolloverWorkflowRunFundingOffer>>(),
+                CancellationToken))
+            .ThrowsAsync(new RecordLockedException());
+
+        // Act
+        var result = await _handler.Handle(command, CancellationToken);
+
+        // Assert
+        result.Success.ShouldBeFalse();
+        result.InnerException.ShouldBeOfType<LockedRecordException>();
+    }
+
+    [Fact]
+    public async Task Handle_WhenAtomicCreateHasMissingDependency_ReturnsDependantNotFoundException()
+    {
+        // Arrange
+        var command = CreateCommand();
+        var foreignKey = Guid.NewGuid();
+        SetupCandidatesAndChecks(command);
+        _repository
+            .Setup(x => x.CreateRolloverWorkflowAsync(
+                It.IsAny<RolloverWorkflowRun>(),
+                It.IsAny<IReadOnlyCollection<RolloverWorkflowCandidate>>(),
+                It.IsAny<IReadOnlyCollection<RolloverWorkflowRunFundingOffer>>(),
+                CancellationToken))
+            .ThrowsAsync(new NoForeignKeyException(foreignKey));
+
+        // Act
+        var result = await _handler.Handle(command, CancellationToken);
+
+        // Assert
+        result.Success.ShouldBeFalse();
+        var exception = result.InnerException.ShouldBeOfType<DependantNotFoundException>();
+        exception.DependantId.ShouldBe(foreignKey);
+    }
+
+    [Fact]
+    public async Task Handle_WhenAtomicCreateThrowsUnexpectedException_ReturnsFailure()
+    {
+        // Arrange
+        var command = CreateCommand();
+        SetupCandidatesAndChecks(command);
+        _repository
+            .Setup(x => x.CreateRolloverWorkflowAsync(
+                It.IsAny<RolloverWorkflowRun>(),
+                It.IsAny<IReadOnlyCollection<RolloverWorkflowCandidate>>(),
+                It.IsAny<IReadOnlyCollection<RolloverWorkflowRunFundingOffer>>(),
+                CancellationToken))
+            .ThrowsAsync(new InvalidOperationException("Database unavailable."));
+
+        // Act
+        var result = await _handler.Handle(command, CancellationToken);
+
+        // Assert
+        result.Success.ShouldBeFalse();
+        result.ErrorMessage.ShouldBe("Database unavailable.");
+        result.InnerException.ShouldBeOfType<InvalidOperationException>();
+    }
+
+    private void SetupCandidatesAndChecks(CreateRolloverWorkflowRunCommand command)
+    {
+        var candidates = CreateCandidates(command.RolloverCandidateIds, command.AcademicYear);
+
+        _repository
+            .Setup(x => x.GetRolloverCandidatesWithP1ChecksAsync(
+                It.IsAny<IReadOnlyCollection<RolloverCandidateP1CheckRequest>>(),
+                CancellationToken))
+            .ReturnsAsync(CreateCandidatesWithChecks(candidates, command));
+    }
+
+    private static CreateRolloverWorkflowRunCommand CreateCommand()
+    {
+        return new CreateRolloverWorkflowRunCommand
         {
-            _fixture = new Fixture().Customize(new AutoMoqCustomization());
-            _repositoryMock = _fixture.Freeze<Mock<IRolloverRepository>>();
-            _handler = _fixture.Create<CreateRolloverWorkflowRunCommandHandler>();
-        }
+            AcademicYear = "2025/26",
+            SelectionMethod = SelectionMethod.QueryBuilder,
+            RolloverCandidateIds = [Guid.NewGuid(), Guid.NewGuid()],
+            FundingOfferIds = [Guid.NewGuid()],
+            FundingEndDateEligibilityThreshold = new DateTime(2025, 1, 1),
+            OperationalEndDateEligibilityThreshold = new DateTime(2025, 2, 1),
+            MaximumApprovalFundingEndDate = new DateTime(2026, 7, 31),
+            CreatedByUserName = "test.user"
+        };
+    }
 
-        [Fact]
-        public async Task Handle_ReturnsSuccess_WhenWorkflowRunAndDependenciesAreCreated()
-        {
-            // Arrange
-            var command = _fixture.Build<CreateRolloverWorkflowRunCommand>()
-                .With(x => x.RolloverCandidateIds, _fixture.CreateMany<Guid>(3).ToList())
-                .With(x => x.FundingOfferIds, _fixture.CreateMany<Guid>(2).ToList())
-                .Create();
+    private static List<RolloverCandidateDto> CreateCandidates(
+        IEnumerable<Guid> candidateIds,
+        string academicYear)
+    {
+        return candidateIds
+            .Select((id, index) => new RolloverCandidateDto
+            {
+                Id = id,
+                QualificationVersionId = Guid.NewGuid(),
+                FundingOfferId = Guid.NewGuid(),
+                AcademicYear = academicYear,
+                RolloverRound = index + 1,
+                PreviousFundingEndDate = new DateTime(2025, 7, 31),
+                NewFundingEndDate = new DateTime(2026, 7, 31)
+            })
+            .ToList();
+    }
 
-            var candidates = command.RolloverCandidateIds
-                .Select(id => new RolloverCandidateDto
+    private static List<RolloverCandidateP1CheckData> CreateCandidatesWithChecks(
+        IEnumerable<RolloverCandidateDto> candidates,
+        CreateRolloverWorkflowRunCommand command)
+    {
+        return candidates
+            .Select(candidate => new RolloverCandidateP1CheckData(
+                candidate,
+                new RolloverWorkflowCandidatesP1Checks
                 {
-                    Id = id,
-                    QualificationVersionId = Guid.NewGuid(),
-                    FundingOfferId = Guid.NewGuid(),
-                    AcademicYear = command.AcademicYear,
-                    RolloverRound = 1,
-                    PreviousFundingEndDate = DateTime.UtcNow.AddDays(-5),
-                    NewFundingEndDate = DateTime.UtcNow.AddDays(10)
-                })
-                .ToList();
-
-            _repositoryMock
-                .Setup(r => r.GetRolloverCandidatesByIdsAsync(
-                    command.RolloverCandidateIds,
-                    It.IsAny<CancellationToken>()))
-                .ReturnsAsync(candidates);
-
-            var workflowRun = RolloverWorkflowRun.Create(
-                command.AcademicYear,
-                command.SelectionMethod,
-                command.FundingEndDateEligibilityThreshold,
-                command.OperationalEndDateEligibilityThreshold,
-                command.MaximumApprovalFundingEndDate,
-                command.CreatedByUserName!,
-                DateTime.UtcNow);
-
-            var workflowRunId = Guid.NewGuid();
-
-            _repositoryMock
-                .Setup(r => r.CreateRolloverWorkflowRunAsync(
-                    It.IsAny<RolloverWorkflowRun>(),
-                    It.IsAny<CancellationToken>()))
-                .ReturnsAsync(workflowRunId);
-
-            _repositoryMock
-                .Setup(r => r.CreateRolloverWorkflowCandidatesAsync(
-                    It.IsAny<IEnumerable<Data.Entities.Rollover.RolloverWorkflowCandidate>>(),
-                    It.IsAny<CancellationToken>()))
-                .Returns(Task.CompletedTask);
-
-            _repositoryMock
-                .Setup(r => r.CreateRolloverWorkflowRunFundingOffersAsync(
-                    It.IsAny<IEnumerable<RolloverWorkflowRunFundingOffer>>(),
-                    It.IsAny<CancellationToken>()))
-                .Returns(Task.CompletedTask);
-
-            // Act
-            var result = await _handler.Handle(command, CancellationToken.None);
-
-            // Assert
-            Assert.True(result.Success);
-            Assert.NotNull(result.Value);
-            Assert.Equal(workflowRunId, result.Value!.RolloverWorkflowRunId);
-            Assert.Null(result.ErrorMessage);
-
-            _repositoryMock.Verify(r =>
-                r.GetRolloverCandidatesByIdsAsync(command.RolloverCandidateIds, It.IsAny<CancellationToken>()),
-                Times.Once);
-
-            _repositoryMock.Verify(r =>
-                r.CreateRolloverWorkflowRunAsync(
-                    It.IsAny<RolloverWorkflowRun>(),
-                    It.IsAny<CancellationToken>()),
-                Times.Once);
-
-            _repositoryMock.Verify(r =>
-                r.CreateRolloverWorkflowCandidatesAsync(
-                    It.IsAny<IEnumerable<Data.Entities.Rollover.RolloverWorkflowCandidate>>(),
-                    It.IsAny<CancellationToken>()),
-                Times.Once);
-
-            _repositoryMock.Verify(r =>
-                r.CreateRolloverWorkflowRunFundingOffersAsync(
-                    It.IsAny<IEnumerable<RolloverWorkflowRunFundingOffer>>(),
-                    It.IsAny<CancellationToken>()),
-                Times.Once);
-        }
-
-        [Fact]
-        public async Task Handle_ReturnsFailure_WhenCandidateListIsNull()
-        {
-            // Arrange
-            var command = _fixture.Create<CreateRolloverWorkflowRunCommand>();
-            command.RolloverCandidateIds = null!;
-
-            // Act
-            var result = await _handler.Handle(command, CancellationToken.None);
-
-            // Assert
-            Assert.False(result.Success);
-            Assert.NotNull(result.ErrorMessage);
-            Assert.IsType<InvalidOperationException>(result.InnerException);
-        }
-
-        [Fact]
-        public async Task Handle_ReturnsFailure_WhenCandidateListEmpty()
-        {
-            // Arrange
-            var command = _fixture.Create<CreateRolloverWorkflowRunCommand>();
-            command.RolloverCandidateIds = new List<Guid>();
-
-            // Act
-            var result = await _handler.Handle(command, CancellationToken.None);
-
-            // Assert
-            Assert.False(result.Success);
-            Assert.NotNull(result.ErrorMessage);
-            Assert.IsType<InvalidOperationException>(result.InnerException);
-        }
-
-        [Fact]
-        public async Task Handle_ReturnsLockedRecordException_WhenRepositoryThrowsRecordLocked()
-        {
-            // Arrange
-            var command = _fixture.Build<CreateRolloverWorkflowRunCommand>()
-                .With(c => c.RolloverCandidateIds, _fixture.CreateMany<Guid>(2).ToList())
-                .With(c => c.FundingOfferIds, _fixture.CreateMany<Guid>(1).ToList())
-                .Create();
-
-            // Mock: return valid candidates so handler proceeds
-            var candidates = command.RolloverCandidateIds
-                .Select(id => new RolloverCandidateDto
-                {
-                    Id = id,
-                    QualificationVersionId = Guid.NewGuid(),
-                    FundingOfferId = Guid.NewGuid(),
-                    AcademicYear = command.AcademicYear,
-                    RolloverRound = 1,
-                    PreviousFundingEndDate = DateTime.UtcNow.AddDays(-1),
-                    NewFundingEndDate = DateTime.UtcNow.AddDays(10)
-                })
-                .ToList();
-
-            _repositoryMock
-                .Setup(r => r.GetRolloverCandidatesByIdsAsync(
-                    command.RolloverCandidateIds,
-                    It.IsAny<CancellationToken>()))
-                .ReturnsAsync(candidates);
-
-            // Mock: workflow run creation throws
-            _repositoryMock
-                .Setup(r => r.CreateRolloverWorkflowRunAsync(
-                    It.IsAny<RolloverWorkflowRun>(),
-                    It.IsAny<CancellationToken>()))
-                .ThrowsAsync(new RecordLockedException());
-
-            // Must mock downstream methods even if never reached
-            _repositoryMock
-                .Setup(r => r.CreateRolloverWorkflowCandidatesAsync(
-                    It.IsAny<IEnumerable<Data.Entities.Rollover.RolloverWorkflowCandidate>>(),
-                    It.IsAny<CancellationToken>()))
-                .Returns(Task.CompletedTask);
-
-            _repositoryMock
-                .Setup(r => r.CreateRolloverWorkflowRunFundingOffersAsync(
-                    It.IsAny<IEnumerable<RolloverWorkflowRunFundingOffer>>(),
-                    It.IsAny<CancellationToken>()))
-                .Returns(Task.CompletedTask);
-
-            // Act
-            var result = await _handler.Handle(command, CancellationToken.None);
-
-            // Assert
-            Assert.False(result.Success);
-            Assert.IsType<LockedRecordException>(result.InnerException);
-        }
-
-
-        [Fact]
-        public async Task Handle_ReturnsFailure_WhenUnexpectedExceptionThrown()
-        {
-            // Arrange
-            var command = _fixture.Build<CreateRolloverWorkflowRunCommand>()
-                .With(c => c.RolloverCandidateIds, _fixture.CreateMany<Guid>(2).ToList())
-                .With(c => c.FundingOfferIds, _fixture.CreateMany<Guid>(1).ToList())
-                .Create();
-
-            // Return valid rollover candidates so handler continues
-            var candidates = command.RolloverCandidateIds
-                .Select(id => new RolloverCandidateDto
-                {
-                    Id = id,
-                    QualificationVersionId = Guid.NewGuid(),
-                    FundingOfferId = Guid.NewGuid(),
-                    AcademicYear = command.AcademicYear,
-                    RolloverRound = 1,
-                    PreviousFundingEndDate = DateTime.UtcNow.AddDays(-2),
-                    NewFundingEndDate = DateTime.UtcNow.AddDays(5)
-                })
-                .ToList();
-
-            _repositoryMock
-                .Setup(r => r.GetRolloverCandidatesByIdsAsync(
-                    command.RolloverCandidateIds,
-                    It.IsAny<CancellationToken>()))
-                .ReturnsAsync(candidates);
-
-            // THIS is the method we want to throw
-            _repositoryMock
-                .Setup(r => r.CreateRolloverWorkflowRunAsync(
-                    It.IsAny<RolloverWorkflowRun>(),
-                    It.IsAny<CancellationToken>()))
-                .ThrowsAsync(new Exception("Unexpected!"));
-
-            // Must mock downstream calls (even though never reached)
-            _repositoryMock
-                .Setup(r => r.CreateRolloverWorkflowCandidatesAsync(
-                    It.IsAny<IEnumerable<Data.Entities.Rollover.RolloverWorkflowCandidate>>(),
-                    It.IsAny<CancellationToken>()))
-                .Returns(Task.CompletedTask);
-
-            _repositoryMock
-                .Setup(r => r.CreateRolloverWorkflowRunFundingOffersAsync(
-                    It.IsAny<IEnumerable<RolloverWorkflowRunFundingOffer>>(),
-                    It.IsAny<CancellationToken>()))
-                .Returns(Task.CompletedTask);
-
-            // Act
-            var result = await _handler.Handle(command, CancellationToken.None);
-
-            // Assert
-            Assert.False(result.Success);
-            Assert.Equal("Unexpected!", result.ErrorMessage);
-            Assert.IsType<Exception>(result.InnerException);
-        }
-
-        [Fact]
-        public async Task Handle_ReturnsDependantNotFoundException_WhenRepositoryThrowsNoForeignKey()
-        {
-            // Arrange
-            var command = _fixture.Build<CreateRolloverWorkflowRunCommand>()
-                .With(c => c.RolloverCandidateIds, _fixture.CreateMany<Guid>(2).ToList())
-                .With(c => c.FundingOfferIds, _fixture.CreateMany<Guid>(1).ToList())
-                .Create();
-
-            // Mock valid rollover candidates so the handler passes validation
-            var candidates = command.RolloverCandidateIds
-                .Select(id => new RolloverCandidateDto
-                {
-                    Id = id,
-                    QualificationVersionId = Guid.NewGuid(),
-                    FundingOfferId = Guid.NewGuid(),
-                    AcademicYear = command.AcademicYear,
-                    RolloverRound = 1,
-                    PreviousFundingEndDate = DateTime.UtcNow.AddDays(-2),
-                    NewFundingEndDate = DateTime.UtcNow.AddDays(10)
-                })
-                .ToList();
-
-            _repositoryMock
-                .Setup(r => r.GetRolloverCandidatesByIdsAsync(
-                    command.RolloverCandidateIds,
-                    It.IsAny<CancellationToken>()))
-                .ReturnsAsync(candidates);
-
-            var foreignKey = Guid.NewGuid();
-
-            // The specific repository call we want to throw
-            _repositoryMock
-                .Setup(r => r.CreateRolloverWorkflowRunAsync(
-                    It.IsAny<RolloverWorkflowRun>(),
-                    It.IsAny<CancellationToken>()))
-                .ThrowsAsync(new NoForeignKeyException(foreignKey));
-
-            // Downstream methods must still be mocked
-            _repositoryMock
-                .Setup(r => r.CreateRolloverWorkflowCandidatesAsync(
-                    It.IsAny<IEnumerable<Data.Entities.Rollover.RolloverWorkflowCandidate>>(),
-                    It.IsAny<CancellationToken>()))
-                .Returns(Task.CompletedTask);
-
-            _repositoryMock
-                .Setup(r => r.CreateRolloverWorkflowRunFundingOffersAsync(
-                    It.IsAny<IEnumerable<RolloverWorkflowRunFundingOffer>>(),
-                    It.IsAny<CancellationToken>()))
-                .Returns(Task.CompletedTask);
-
-            // Act
-            var result = await _handler.Handle(command, CancellationToken.None);
-
-            // Assert
-            Assert.False(result.Success);
-            Assert.IsType<DependantNotFoundException>(result.InnerException);
-
-            var ex = (DependantNotFoundException)result.InnerException!;
-            Assert.Equal(foreignKey, ex.DependantId);
-        }
+                    RolloverCandidatesId = candidate.Id,
+                    QualificationVersionId = candidate.QualificationVersionId,
+                    FundingOfferId = candidate.FundingOfferId,
+                    AcademicYear = candidate.AcademicYear!,
+                    FundingStream = "AdultSkills",
+                    FundingEndDateThreshold = command.FundingEndDateEligibilityThreshold,
+                    OperationalEndDateThreshold = command.OperationalEndDateEligibilityThreshold,
+                    MaximumApprovalEndDate = command.MaximumApprovalFundingEndDate,
+                    OfferedInEngland = true,
+                    IntentionToSeekFundingInEngland = true
+                }))
+            .ToList();
     }
 }

--- a/src/SFA.DAS.AODP.Application.Tests/Commands/Rollover/SubmitRolloverExtensionCommandHandlerTests.cs
+++ b/src/SFA.DAS.AODP.Application.Tests/Commands/Rollover/SubmitRolloverExtensionCommandHandlerTests.cs
@@ -1,5 +1,6 @@
 ﻿using AutoFixture;
 using AutoFixture.AutoMoq;
+using Microsoft.Extensions.Logging;
 using Moq;
 using SFA.DAS.AODP.Application.Commands.Rollover;
 using SFA.DAS.AODP.Application.Services.FundingExtension;
@@ -17,6 +18,7 @@ namespace SFA.DAS.AODP.Application.Tests.Commands.Rollover
         private readonly Mock<IRolloverRepository> _rolloverRepository = new();
         private readonly Mock<IQualificationFundingsRepository> _fundingsRepository = new();
         private readonly Mock<ISubmitFundingExtensionService> _applyService = new();
+        private readonly Mock<ILogger<SubmitRolloverExtensionCommandHandler>> _logger = new();
         private readonly IFixture _fixture = new Fixture().Customize(new AutoMoqCustomization());
 
         private readonly SubmitRolloverExtensionCommandHandler _handler;
@@ -34,14 +36,15 @@ namespace SFA.DAS.AODP.Application.Tests.Commands.Rollover
             _handler = new SubmitRolloverExtensionCommandHandler(
                 _rolloverRepository.Object,
                 _fundingsRepository.Object,
-                _applyService.Object);
+                _applyService.Object,
+                _logger.Object);
         }
 
         // ------------------------------------------------------------
-        // SUCCESS — APPLY EXTENSIONS → SAVE CHANGES
+        // SUCCESS — APPLY EXTENSIONS
         // ------------------------------------------------------------
         [Fact]
-        public async Task Handle_Success_AppliesExtensionsAndSavesChanges()
+        public async Task Handle_Success_AppliesExtensionsWithoutTrackedSaveChanges()
         {
             // Arrange
             var item1 = new FundingExtensionItem() { Qan = "111", FundingStreamName = "16-18", RolloverStatus = "Extended", ProposedFundingApprovalEndDate = DateTime.UtcNow.AddYears(1) };
@@ -85,7 +88,7 @@ namespace SFA.DAS.AODP.Application.Tests.Commands.Rollover
             Assert.True(result.Success);
             Assert.Equal("Funding extensions applied.", result.Value.ResultMessage);
 
-            _rolloverRepository.Verify(r => r.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+            _rolloverRepository.Verify(r => r.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
         }
 
         [Fact]

--- a/src/SFA.DAS.AODP.Application.Tests/Commands/Rollover/UpdateRolloverWorkflowCandidatesAfterP1ChecksCommandHandlerTests.cs
+++ b/src/SFA.DAS.AODP.Application.Tests/Commands/Rollover/UpdateRolloverWorkflowCandidatesAfterP1ChecksCommandHandlerTests.cs
@@ -1,204 +1,254 @@
-﻿using Moq;
+using Moq;
 using SFA.DAS.AODP.Application.Commands.Rollover;
 using SFA.DAS.AODP.Data.Entities.Rollover;
+using SFA.DAS.AODP.Data.Entities.Rollover.Enums;
 using SFA.DAS.AODP.Data.Repositories.Rollover;
+using SFA.DAS.AODP.Models.Rollover;
+using Shouldly;
 using System.Reflection;
 
 namespace SFA.DAS.AODP.Application.UnitTests.Commands.Rollover;
 
-public class UpdateRolloverWorkflowCandidatesAfterP1ChecksCommandHandlerTests
+public class UpdateRolloverWorkflowCandidatesAfterP1ChecksCommandHandlerTests : UnitTest
 {
-    private readonly Mock<IRolloverRepository> _repoMock;
+    private readonly Mock<IRolloverRepository> _repository = new();
     private readonly UpdateRolloverWorkflowCandidatesAfterP1ChecksCommandHandler _handler;
 
     public UpdateRolloverWorkflowCandidatesAfterP1ChecksCommandHandlerTests()
     {
-        _repoMock = new Mock<IRolloverRepository>();
-        _handler = new UpdateRolloverWorkflowCandidatesAfterP1ChecksCommandHandler(_repoMock.Object);
+        _handler = new UpdateRolloverWorkflowCandidatesAfterP1ChecksCommandHandler(
+            _repository.Object);
     }
 
     [Fact]
-    public async Task Handle_NoChecks_ReturnsSuccess_AndDoesNotSave()
+    public async Task Handle_WhenThereAreNoCandidates_ReturnsSuccessWithoutSaving()
     {
-        _repoMock.Setup(r => r.GetRolloverWorkflowCandidatesP1ChecksAsync(It.IsAny<CancellationToken>()))
-                 .ReturnsAsync([]);
+        // Arrange
+        _repository
+            .Setup(x => x.GetAllRolloverWorkflowCandidatesAsync(CancellationToken))
+            .ReturnsAsync([]);
+        _repository
+            .Setup(x => x.GetRolloverCandidatesWithP1ChecksAsync(
+                It.Is<IReadOnlyCollection<RolloverCandidateP1CheckRequest>>(
+                    requests => requests.Count == 0),
+                CancellationToken))
+            .ReturnsAsync([]);
 
-        _repoMock.Setup(r => r.GetAllRolloverWorkflowCandidatesAsync(It.IsAny<CancellationToken>()))
-                 .ReturnsAsync([]);
+        // Act
+        var result = await _handler.Handle(
+            new UpdateRolloverWorkflowCandidatesAfterP1ChecksCommand(),
+            CancellationToken);
 
-        var result = await _handler.Handle(new UpdateRolloverWorkflowCandidatesAfterP1ChecksCommand(), CancellationToken.None);
-
-        Assert.True(result.Success);
-        _repoMock.Verify(r => r.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+        // Assert
+        result.Success.ShouldBeTrue();
+        _repository.Verify(
+            x => x.SaveChangesAsync(It.IsAny<CancellationToken>()),
+            Times.Never);
     }
 
     [Fact]
-    public async Task Handle_CandidatePassesAllChecks_UpdatesCandidate()
+    public async Task Handle_WhenCandidatePassesAllChecks_UpdatesAndSavesCandidate()
     {
-        var id = Guid.NewGuid();
-
-        var candidate = CreateCandidate(id, DateTime.UtcNow.AddDays(-1));
-
-        var p1 = new RolloverWorkflowCandidatesP1Checks
+        // Arrange
+        var candidate = CreateCandidate(new DateTime(2025, 7, 31));
+        var check = new RolloverWorkflowCandidatesP1Checks
         {
-            WorkflowCandidateId = id,
-            FundingStream = "FS",
-            LatestFundingApprovalEndDate = null,
-            FundingEndDateThreshold = DateTime.UtcNow.AddDays(-10),
-            OperationalEndDate = null,
-            OperationalEndDateThreshold = DateTime.UtcNow.AddDays(-10),
+            RolloverCandidatesId = candidate.RolloverCandidatesId,
+            FundingStream = "AdultSkills",
+            FundingEndDateThreshold = new DateTime(2025, 1, 1),
+            OperationalEndDateThreshold = new DateTime(2025, 1, 1),
             OfferedInEngland = true,
-            IntentionToSeekFundingInEngland = true,
-            IsOnDefundingList = false
+            IntentionToSeekFundingInEngland = true
         };
+        SetupCandidateAndCheck(candidate, check);
 
-        _repoMock.Setup(r => r.GetRolloverWorkflowCandidatesP1ChecksAsync(It.IsAny<CancellationToken>()))
-                 .ReturnsAsync([p1]);
+        // Act
+        var result = await _handler.Handle(
+            new UpdateRolloverWorkflowCandidatesAfterP1ChecksCommand(),
+            CancellationToken);
 
-        _repoMock.Setup(r => r.GetAllRolloverWorkflowCandidatesAsync(It.IsAny<CancellationToken>()))
-                 .ReturnsAsync([candidate]);
-
-        _repoMock.Setup(r => r.SaveChangesAsync(It.IsAny<CancellationToken>()))
-                 .Returns(Task.CompletedTask);
-
-        var result = await _handler.Handle(new UpdateRolloverWorkflowCandidatesAfterP1ChecksCommand(), CancellationToken.None);
-
-        Assert.True(result.Success);
-        _repoMock.Verify(r => r.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
-
-        Assert.True(candidate.PassP1);
-        Assert.Null(candidate.P1FailureReason);
+        // Assert
+        result.Success.ShouldBeTrue();
+        candidate.PassP1.ShouldBeTrue();
+        candidate.P1FailureReason.ShouldBeNull();
+        _repository.Verify(
+            x => x.SaveChangesAsync(CancellationToken),
+            Times.Once);
     }
 
     [Fact]
-    public async Task Handle_CandidateFailsAllChecks_SetsFailureReason()
+    public async Task Handle_WhenCandidateFailsChecks_SetsFailureDetailsAndSavesCandidate()
     {
-        var id = Guid.NewGuid();
-        var candidate = CreateCandidate(id, DateTime.UtcNow.AddDays(-5));
-
-        var p1 = new RolloverWorkflowCandidatesP1Checks
+        // Arrange
+        var candidate = CreateCandidate(new DateTime(2025, 7, 31));
+        var check = new RolloverWorkflowCandidatesP1Checks
         {
-            WorkflowCandidateId = id,
+            RolloverCandidatesId = candidate.RolloverCandidatesId,
             FundingStream = null,
-            LatestFundingApprovalEndDate = DateTime.UtcNow.AddDays(-10),
-            FundingEndDateThreshold = DateTime.UtcNow.AddDays(-5),
-            OperationalEndDate = DateTime.UtcNow.AddDays(-20),
-            OperationalEndDateThreshold = DateTime.UtcNow.AddDays(-18),
+            LatestFundingApprovalEndDate = new DateTime(2024, 1, 1),
+            FundingEndDateThreshold = new DateTime(2025, 1, 1),
+            OperationalEndDate = new DateTime(2024, 1, 1),
+            OperationalEndDateThreshold = new DateTime(2025, 1, 1),
             OfferedInEngland = false,
             IntentionToSeekFundingInEngland = false,
             IsOnDefundingList = true
         };
+        SetupCandidateAndCheck(candidate, check);
 
-        _repoMock.Setup(r => r.GetRolloverWorkflowCandidatesP1ChecksAsync(It.IsAny<CancellationToken>()))
-                 .ReturnsAsync([p1]);
+        // Act
+        var result = await _handler.Handle(
+            new UpdateRolloverWorkflowCandidatesAfterP1ChecksCommand(),
+            CancellationToken);
 
-        _repoMock.Setup(r => r.GetAllRolloverWorkflowCandidatesAsync(It.IsAny<CancellationToken>()))
-                 .ReturnsAsync([candidate]);
-
-        _repoMock.Setup(r => r.SaveChangesAsync(It.IsAny<CancellationToken>()))
-                 .Returns(Task.CompletedTask);
-
-        var result = await _handler.Handle(new UpdateRolloverWorkflowCandidatesAfterP1ChecksCommand(), CancellationToken.None);
-
-        Assert.True(result.Success);
-        _repoMock.Verify(r => r.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
-
-        Assert.False(candidate.PassP1);
-        Assert.NotNull(candidate.P1FailureReason);
-
-        Assert.Contains("Funding Stream out of scope for RollOver", candidate.P1FailureReason);
-        Assert.Contains("Funding Approval End Date is before the Threshold", candidate.P1FailureReason);
-        Assert.Contains("Operating End Date is before the Threshold", candidate.P1FailureReason);
-        Assert.Contains("Not Offered in England", candidate.P1FailureReason);
-        Assert.Contains("Not Funded in England", candidate.P1FailureReason);
-        Assert.Contains("Qualification is on Defunding (Defunded) List", candidate.P1FailureReason);
+        // Assert
+        result.Success.ShouldBeTrue();
+        candidate.PassP1.ShouldBeFalse();
+        candidate.P1FailureReason.ShouldBe(
+            "Funding Stream out of scope for RollOver; " +
+            "Funding Approval End Date is before the Threshold; " +
+            "Operating End Date is before the Threshold; " +
+            "Not Offered in England; " +
+            "Not Funded in England; " +
+            "Qualification is on Defunding (Defunded) List");
+        _repository.Verify(
+            x => x.SaveChangesAsync(CancellationToken),
+            Times.Once);
     }
 
     [Fact]
-    public async Task Handle_CandidateNotFound_DoesNotSave()
+    public async Task Handle_WhenNoCheckIsReturnedForCandidate_DoesNotSave()
     {
-        var p1 = new RolloverWorkflowCandidatesP1Checks
-        {
-            WorkflowCandidateId = Guid.NewGuid()
-        };
+        // Arrange
+        var candidate = CreateCandidate(new DateTime(2025, 7, 31));
+        _repository
+            .Setup(x => x.GetAllRolloverWorkflowCandidatesAsync(CancellationToken))
+            .ReturnsAsync([candidate]);
+        _repository
+            .Setup(x => x.GetRolloverCandidatesWithP1ChecksAsync(
+                It.IsAny<IReadOnlyCollection<RolloverCandidateP1CheckRequest>>(),
+                CancellationToken))
+            .ReturnsAsync([]);
 
-        _repoMock.Setup(r => r.GetRolloverWorkflowCandidatesP1ChecksAsync(It.IsAny<CancellationToken>()))
-                 .ReturnsAsync([p1]);
+        // Act
+        var result = await _handler.Handle(
+            new UpdateRolloverWorkflowCandidatesAfterP1ChecksCommand(),
+            CancellationToken);
 
-        _repoMock.Setup(r => r.GetAllRolloverWorkflowCandidatesAsync(It.IsAny<CancellationToken>()))
-                 .ReturnsAsync([]);
-
-        var result = await _handler.Handle(new UpdateRolloverWorkflowCandidatesAfterP1ChecksCommand(), CancellationToken.None);
-
-        Assert.True(result.Success);
-        _repoMock.Verify(r => r.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
-    }
-
-    [Fact]
-    public async Task Handle_WhenRepositoryThrows_ReturnsFailure()
-    {
-        var ex = new InvalidOperationException("error");
-
-        _repoMock.Setup(r => r.GetRolloverWorkflowCandidatesP1ChecksAsync(It.IsAny<CancellationToken>()))
-                 .ThrowsAsync(ex);
-
-        var result = await _handler.Handle(new UpdateRolloverWorkflowCandidatesAfterP1ChecksCommand(), CancellationToken.None);
-
-        Assert.False(result.Success);
-        Assert.Equal("error", result.ErrorMessage);
-        Assert.Same(ex, result.InnerException);
+        // Assert
+        result.Success.ShouldBeTrue();
+        _repository.Verify(
+            x => x.SaveChangesAsync(It.IsAny<CancellationToken>()),
+            Times.Never);
     }
 
     [Fact]
     public async Task Handle_WhenCandidateFails_RevertsProposedFundingEndDateToCurrent()
     {
-        var id = Guid.NewGuid();
-        var current = new DateTime(2024, 4, 30);
-        var initialProposed = new DateTime(2025, 1, 1);
-
-        var candidate = CreateCandidate(id, current, initialProposed);
-
-        var p1 = new RolloverWorkflowCandidatesP1Checks
+        // Arrange
+        var currentFundingEndDate = new DateTime(2024, 4, 30);
+        var candidate = CreateCandidate(
+            currentFundingEndDate,
+            new DateTime(2025, 1, 1));
+        var check = new RolloverWorkflowCandidatesP1Checks
         {
-            WorkflowCandidateId = id,
+            RolloverCandidatesId = candidate.RolloverCandidatesId,
             FundingStream = null,
-            FundingEndDateThreshold = DateTime.UtcNow,
-            OperationalEndDateThreshold = DateTime.UtcNow,
             OfferedInEngland = false,
             IsOnDefundingList = true
         };
+        SetupCandidateAndCheck(candidate, check);
 
-        _repoMock.Setup(r => r.GetRolloverWorkflowCandidatesP1ChecksAsync(It.IsAny<CancellationToken>()))
-                 .ReturnsAsync([p1]);
+        // Act
+        var result = await _handler.Handle(
+            new UpdateRolloverWorkflowCandidatesAfterP1ChecksCommand(),
+            CancellationToken);
 
-        _repoMock.Setup(r => r.GetAllRolloverWorkflowCandidatesAsync(It.IsAny<CancellationToken>()))
-                 .ReturnsAsync([candidate]);
-
-        _repoMock.Setup(r => r.SaveChangesAsync(It.IsAny<CancellationToken>()))
-                 .Returns(Task.CompletedTask);
-
-        var result = await _handler.Handle(new UpdateRolloverWorkflowCandidatesAfterP1ChecksCommand(), CancellationToken.None);
-
-        Assert.True(result.Success);
-        Assert.Equal(current, candidate.ProposedFundingEndDate);
+        // Assert
+        result.Success.ShouldBeTrue();
+        candidate.ProposedFundingEndDate.ShouldBe(currentFundingEndDate);
     }
 
-    private static RolloverWorkflowCandidate CreateCandidate(Guid id, DateTime currentFundingEnd, DateTime? proposedFundingEndDate = null)
+    [Fact]
+    public async Task Handle_WhenRepositoryThrows_ReturnsFailure()
     {
+        // Arrange
+        var exception = new InvalidOperationException("Database unavailable.");
+        _repository
+            .Setup(x => x.GetAllRolloverWorkflowCandidatesAsync(CancellationToken))
+            .ThrowsAsync(exception);
+
+        // Act
+        var result = await _handler.Handle(
+            new UpdateRolloverWorkflowCandidatesAfterP1ChecksCommand(),
+            CancellationToken);
+
+        // Assert
+        result.Success.ShouldBeFalse();
+        result.ErrorMessage.ShouldBe(exception.Message);
+        result.InnerException.ShouldBeSameAs(exception);
+    }
+
+    private void SetupCandidateAndCheck(
+        RolloverWorkflowCandidate candidate,
+        RolloverWorkflowCandidatesP1Checks check)
+    {
+        _repository
+            .Setup(x => x.GetAllRolloverWorkflowCandidatesAsync(CancellationToken))
+            .ReturnsAsync([candidate]);
+        _repository
+            .Setup(x => x.GetRolloverCandidatesWithP1ChecksAsync(
+                It.Is<IReadOnlyCollection<RolloverCandidateP1CheckRequest>>(requests =>
+                    requests.Count == 1 &&
+                    requests.Single().RolloverCandidateId ==
+                    candidate.RolloverCandidatesId &&
+                    requests.Single().FundingEndDateEligibilityThreshold ==
+                    candidate.RolloverWorkflowRun.FundingEndDateEligibilityThreshold),
+                CancellationToken))
+            .ReturnsAsync([
+                new RolloverCandidateP1CheckData(
+                    new RolloverCandidateDto
+                    {
+                        Id = candidate.RolloverCandidatesId,
+                        QualificationVersionId = candidate.QualificationVersionId,
+                        FundingOfferId = candidate.FundingOfferId,
+                        AcademicYear = candidate.AcademicYear,
+                        RolloverRound = candidate.RolloverRound
+                    },
+                    check)
+            ]);
+        _repository
+            .Setup(x => x.SaveChangesAsync(CancellationToken))
+            .Returns(Task.CompletedTask);
+    }
+
+    private static RolloverWorkflowCandidate CreateCandidate(
+        DateTime currentFundingEndDate,
+        DateTime? proposedFundingEndDate = null)
+    {
+        var workflowRun = RolloverWorkflowRun.Create(
+            "2024/25",
+            SelectionMethod.QueryBuilder,
+            new DateTime(2025, 1, 1),
+            new DateTime(2025, 2, 1),
+            new DateTime(2026, 7, 31),
+            "test.user",
+            new DateTime(2024, 1, 1));
         var candidate = RolloverWorkflowCandidate.Create(
-            Guid.NewGuid(),
+            workflowRun.Id,
             Guid.NewGuid(),
             Guid.NewGuid(),
             Guid.NewGuid(),
             "2024/25",
             1,
-            currentFundingEnd,
+            currentFundingEndDate,
             proposedFundingEndDate,
-            currentFundingEnd.AddDays(-1));
+            new DateTime(2024, 1, 1));
 
         typeof(RolloverWorkflowCandidate)
-            .GetField("<Id>k__BackingField", BindingFlags.Instance | BindingFlags.NonPublic)!
-            .SetValue(candidate, id);
+            .GetProperty(
+                nameof(RolloverWorkflowCandidate.RolloverWorkflowRun),
+                BindingFlags.Instance | BindingFlags.Public)!
+            .SetValue(candidate, workflowRun);
 
         return candidate;
     }

--- a/src/SFA.DAS.AODP.Application.Tests/Commands/Rollover/ValidateRolloverExtensionCommandHandlerTests.cs
+++ b/src/SFA.DAS.AODP.Application.Tests/Commands/Rollover/ValidateRolloverExtensionCommandHandlerTests.cs
@@ -1,4 +1,5 @@
 ﻿using Moq;
+using Microsoft.Extensions.Logging;
 using SFA.DAS.AODP.Application.Commands.Rollover;
 using SFA.DAS.AODP.Application.Services.Export;
 using SFA.DAS.AODP.Application.Services.FundingExtension;
@@ -14,6 +15,7 @@ namespace SFA.DAS.AODP.Application.Tests.Commands.Rollover
         private readonly Mock<IRolloverFundingExtensionValidator> _validator = new();
         private readonly Mock<IFundingExtensionCandidatesCsvBuilder> _csvBuilder = new();
         private readonly Mock<IFundingExtensionProjectionService> _projectionService = new();
+        private readonly Mock<ILogger<ValidateRolloverExtensionCommandHandler>> _logger = new();
 
         private readonly ValidateRolloverExtensionCommandHandler _handler;
         private readonly DateTime _defaultEndDate = DateTime.UtcNow.AddDays(20);
@@ -24,7 +26,8 @@ namespace SFA.DAS.AODP.Application.Tests.Commands.Rollover
                 _rolloverRepository.Object,
                 _validator.Object,
                 _csvBuilder.Object,
-                _projectionService.Object);
+                _projectionService.Object,
+                _logger.Object);
         }
 
         // ------------------------------------------------------------

--- a/src/SFA.DAS.AODP.Application.Tests/Queries/Rollover/GetRolloverCandidatesForExportQueryHandlerTests.cs
+++ b/src/SFA.DAS.AODP.Application.Tests/Queries/Rollover/GetRolloverCandidatesForExportQueryHandlerTests.cs
@@ -55,7 +55,7 @@ namespace SFA.DAS.AODP.Application.UnitTests.Queries.Rollover
             Assert.True(result.Success);
             Assert.NotNull(result.Value);
             Assert.Equal(csvBytes, result.Value.FileContent);
-            Assert.Equal($"RolloverCandidates_SystemDraft_{DateOnly.FromDateTime(DateTime.Today).ToFilenameDateFormat()}.csv", result.Value.FileName);
+            Assert.Equal($"RolloverCandidates_SystemDraft_{DateOnly.FromDateTime(DateTime.UtcNow.Date).ToFilenameDateFormat()}.csv", result.Value.FileName);
             Assert.Equal("text/csv", result.Value.ContentType);
             Assert.Null(result.ErrorMessage);
         }

--- a/src/SFA.DAS.AODP.Application.Tests/Services/SubmitFundingExtensionServiceTests.cs
+++ b/src/SFA.DAS.AODP.Application.Tests/Services/SubmitFundingExtensionServiceTests.cs
@@ -4,6 +4,7 @@ using Moq;
 using SFA.DAS.AODP.Application.Commands.Rollover;
 using SFA.DAS.AODP.Application.Services.FundingExtension;
 using SFA.DAS.AODP.Application.UnitTests.Helpers;
+using SFA.DAS.AODP.Data.Context;
 using SFA.DAS.AODP.Data.Entities.Qualification;
 using SFA.DAS.AODP.Data.Entities.Rollover;
 using SFA.DAS.AODP.Data.Repositories.Qualification;
@@ -19,6 +20,7 @@ namespace SFA.DAS.AODP.Application.Tests.Services.Rollover
         private readonly Mock<IQualificationDiscussionHistoryRepository> _historyRepository = new();
         private readonly Mock<ISystemClockService> _clockService = new();
         private readonly Mock<IGuidProvider> _guidProvider = new();
+        private readonly Mock<IApplicationDbContext> _dbContext = new();
         private readonly IFixture _fixture = new Fixture().Customize(new AutoMoqCustomization());
 
         private readonly SubmitFundingExtensionService _service;
@@ -36,7 +38,8 @@ namespace SFA.DAS.AODP.Application.Tests.Services.Rollover
                 _rolloverRepository.Object,
                 _historyRepository.Object,
                 _clockService.Object,
-                _guidProvider.Object);
+                _guidProvider.Object,
+                _dbContext.Object);
         }
 
         // ------------------------------------------------------------

--- a/src/SFA.DAS.AODP.Application.Tests/Services/SubmitFundingExtensionServiceTests.cs
+++ b/src/SFA.DAS.AODP.Application.Tests/Services/SubmitFundingExtensionServiceTests.cs
@@ -1,5 +1,6 @@
 ﻿using AutoFixture;
 using AutoFixture.AutoMoq;
+using Microsoft.EntityFrameworkCore.Storage;
 using Moq;
 using SFA.DAS.AODP.Application.Commands.Rollover;
 using SFA.DAS.AODP.Application.Services.FundingExtension;
@@ -40,6 +41,14 @@ namespace SFA.DAS.AODP.Application.Tests.Services.Rollover
                 _clockService.Object,
                 _guidProvider.Object,
                 _dbContext.Object);
+
+            var transactionMock = new Mock<IDbContextTransaction>();
+
+            transactionMock.Setup(t => t.Rollback());
+            transactionMock.Setup(t => t.CommitAsync());
+
+            var transaction = transactionMock.Object;
+            _dbContext.Setup(o => o.StartTransactionAsync()).ReturnsAsync(transaction);
         }
 
         // ------------------------------------------------------------

--- a/src/SFA.DAS.AODP.Application.Tests/Services/SubmitFundingExtensionServiceTests.cs
+++ b/src/SFA.DAS.AODP.Application.Tests/Services/SubmitFundingExtensionServiceTests.cs
@@ -1,273 +1,275 @@
-﻿using AutoFixture;
+using AutoFixture;
 using AutoFixture.AutoMoq;
-using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.Extensions.Logging;
 using Moq;
 using SFA.DAS.AODP.Application.Commands.Rollover;
 using SFA.DAS.AODP.Application.Services.FundingExtension;
+using SFA.DAS.AODP.Application.UnitTests;
 using SFA.DAS.AODP.Application.UnitTests.Helpers;
-using SFA.DAS.AODP.Data.Context;
 using SFA.DAS.AODP.Data.Entities.Qualification;
 using SFA.DAS.AODP.Data.Entities.Rollover;
-using SFA.DAS.AODP.Data.Repositories.Qualification;
-using SFA.DAS.AODP.Data.Repositories.Rollover;
+using SFA.DAS.AODP.Data.Repositories.FundingExtension;
 using SFA.DAS.AODP.Infrastructure.Services.Interfaces;
 using SFA.DAS.AODP.Models.Rollover;
+using Shouldly;
 
-namespace SFA.DAS.AODP.Application.Tests.Services.Rollover
+namespace SFA.DAS.AODP.Application.Tests.Services.Rollover;
+
+public class SubmitFundingExtensionServiceTests : UnitTest
 {
-    public class SubmitFundingExtensionServiceTests
+    private readonly Mock<IFundingExtensionPersistenceRepository> _persistenceRepository = new();
+    private readonly Mock<ISystemClockService> _clockService = new();
+    private readonly Mock<IGuidProvider> _guidProvider = new();
+    private readonly Mock<ILogger<SubmitFundingExtensionService>> _logger = new();
+    private readonly IFixture _fixture = new Fixture().Customize(new AutoMoqCustomization());
+    private readonly SubmitFundingExtensionService _service;
+
+    public SubmitFundingExtensionServiceTests()
     {
-        private readonly Mock<IRolloverRepository> _rolloverRepository = new();
-        private readonly Mock<IQualificationDiscussionHistoryRepository> _historyRepository = new();
-        private readonly Mock<ISystemClockService> _clockService = new();
-        private readonly Mock<IGuidProvider> _guidProvider = new();
-        private readonly Mock<IApplicationDbContext> _dbContext = new();
-        private readonly IFixture _fixture = new Fixture().Customize(new AutoMoqCustomization());
+        _fixture.Behaviors
+            .OfType<ThrowingRecursionBehavior>()
+            .ToList()
+            .ForEach(behavior => _fixture.Behaviors.Remove(behavior));
 
-        private readonly SubmitFundingExtensionService _service;
+        _fixture.Behaviors.Add(new OmitOnRecursionBehavior());
 
-        public SubmitFundingExtensionServiceTests()
+        _service = new SubmitFundingExtensionService(
+            _persistenceRepository.Object,
+            _clockService.Object,
+            _guidProvider.Object,
+            _logger.Object);
+    }
+
+    [Fact]
+    public async Task Submit_WhenCandidateIsExtended_PersistsCandidateFundingAndHistory()
+    {
+        // Arrange
+        var item = new FundingExtensionItem
         {
-            _fixture.Behaviors
-                .OfType<ThrowingRecursionBehavior>()
-                .ToList()
-                .ForEach(b => _fixture.Behaviors.Remove(b));
+            Qan = "111",
+            FundingStreamName = "FS",
+            RolloverStatus = "Extended",
+            ProposedFundingApprovalEndDate = new DateTime(2027, 10, 6),
+            Comments = "Test comment"
+        };
 
-            _fixture.Behaviors.Add(new OmitOnRecursionBehavior());
-
-            _service = new SubmitFundingExtensionService(
-                _rolloverRepository.Object,
-                _historyRepository.Object,
-                _clockService.Object,
-                _guidProvider.Object,
-                _dbContext.Object);
-
-            var transactionMock = new Mock<IDbContextTransaction>();
-
-            transactionMock.Setup(t => t.Rollback());
-            transactionMock.Setup(t => t.CommitAsync());
-
-            var transaction = transactionMock.Object;
-            _dbContext.Setup(o => o.StartTransactionAsync()).ReturnsAsync(transaction);
-        }
-
-        // ------------------------------------------------------------
-        // SUCCESS — EXTENDED STATUS UPDATES FUNDING + CANDIDATE
-        // ------------------------------------------------------------
-        [Fact]
-        public async Task Submit_Extended_UpdatesCandidateAndFunding_AndCreatesHistory()
+        var historyId = Guid.NewGuid();
+        var qualificationId = Guid.NewGuid();
+        var qualificationVersionId = Guid.NewGuid();
+        var timestamp = new DateTime(2026, 10, 1, 12, 0, 0);
+        var candidate = CandidateHelper.BuildCandidate(
+            _fixture,
+            item.Qan,
+            item.FundingStreamName,
+            qualificationVersionId,
+            qualificationId);
+        var funding = new QualificationFundings
         {
-            // Arrange
-            var item = new FundingExtensionItem
+            QualificationVersionId = qualificationVersionId,
+            QualificationVersion = new QualificationVersions
             {
-                Qan = "111",
-                FundingStreamName = "FS",
-                RolloverStatus = "Extended",
-                ProposedFundingApprovalEndDate = new DateTime(2027, 10, 06, 00,00, 00),
-                Comments = "Test comment"
-            };
+                Id = qualificationVersionId,
+                QualificationId = qualificationId
+            },
+            FundingOfferId = candidate.FundingOfferId
+        };
 
-            var historyId = Guid.NewGuid();
-            var qualificationId = Guid.NewGuid();
-            var qualificationVersionId = Guid.NewGuid();
-            var timestamp = new DateTime(2026, 10, 01, 12, 00, 00);
+        IReadOnlyCollection<RolloverCandidates>? persistedCandidates = null;
+        IReadOnlyCollection<QualificationFundings>? persistedFundings = null;
+        IReadOnlyCollection<QualificationDiscussionHistory>? persistedHistories = null;
 
-            var candidate = CandidateHelper.BuildCandidate(_fixture, item.Qan, item.FundingStreamName, qualificationVersionId, qualificationId);
-
-            var funding = new QualificationFundings
-            {
-                EndDate = new DateOnly(2027, 10, 06),
-                QualificationVersionId = qualificationVersionId,
-                QualificationVersion = new QualificationVersions
+        _guidProvider.Setup(provider => provider.NewGuid()).Returns(historyId);
+        _clockService.Setup(service => service.UtcNow).Returns(timestamp);
+        _persistenceRepository
+            .Setup(repository => repository.PersistAsync(
+                It.IsAny<IReadOnlyCollection<RolloverCandidates>>(),
+                It.IsAny<IReadOnlyCollection<QualificationFundings>>(),
+                It.IsAny<IReadOnlyCollection<QualificationDiscussionHistory>>(),
+                CancellationToken))
+            .Callback<IReadOnlyCollection<RolloverCandidates>, IReadOnlyCollection<QualificationFundings>,
+                IReadOnlyCollection<QualificationDiscussionHistory>, CancellationToken>(
+                (candidates, fundings, histories, _) =>
                 {
-                    Id = qualificationVersionId,
-                    QualificationId = qualificationId
-                },
-                FundingOfferId = candidate.FundingOfferId
-            };
+                    persistedCandidates = candidates;
+                    persistedFundings = fundings;
+                    persistedHistories = histories;
+                })
+            .Returns(Task.CompletedTask);
 
-            var candidates = new List<RolloverCandidates> { candidate };
-            var fundings = new List<QualificationFundings> { funding };
+        // Act
+        var result = await _service.Submit([candidate], [item], [funding], CancellationToken);
 
-            _guidProvider.Setup(o => o.NewGuid()).Returns(historyId);
-            _clockService.Setup(o => o.UtcNow).Returns(timestamp);
+        // Assert
+        result.ShouldBeTrue();
+        persistedCandidates.ShouldBe([candidate]);
+        persistedFundings.ShouldBe([funding]);
+        persistedHistories.ShouldNotBeNull();
+        persistedHistories.Single().ShouldBeEquivalentTo(new QualificationDiscussionHistory
+        {
+            Id = historyId,
+            QualificationId = qualificationId,
+            UserDisplayName = "Rollover System",
+            Title = "Rollover Funding Decision",
+            Timestamp = timestamp,
+            Notes = "FS extended to 06-10-2027",
+            ActionTypeId = Guid.Parse("00000000-0000-0000-0000-000000000004")
+        });
+        candidate.RolloverStatus.ShouldBe(RolloverStatus.Extended);
+        funding.EndDate.ShouldBe(new DateOnly(2027, 10, 6));
+        funding.Comments.ShouldBe(item.Comments);
+    }
 
-            var expectedQualificationDiscussionHistories = new List<QualificationDiscussionHistory>
-            {
-                new QualificationDiscussionHistory
+    [Fact]
+    public async Task Submit_WhenCandidateIsExcluded_PersistsCandidateAndHistoryWithoutFunding()
+    {
+        // Arrange
+        var item = new FundingExtensionItem
+        {
+            Qan = "111",
+            FundingStreamName = "FS",
+            RolloverStatus = "Excluded",
+            ExclusionReason = "Bad data"
+        };
+        var candidate = CandidateHelper.BuildCandidate(_fixture, item.Qan, item.FundingStreamName);
+        IReadOnlyCollection<QualificationFundings>? persistedFundings = null;
+        IReadOnlyCollection<QualificationDiscussionHistory>? persistedHistories = null;
+
+        _persistenceRepository
+            .Setup(repository => repository.PersistAsync(
+                It.Is<IReadOnlyCollection<RolloverCandidates>>(values => values.Count == 1),
+                It.IsAny<IReadOnlyCollection<QualificationFundings>>(),
+                It.IsAny<IReadOnlyCollection<QualificationDiscussionHistory>>(),
+                CancellationToken))
+            .Callback<IReadOnlyCollection<RolloverCandidates>, IReadOnlyCollection<QualificationFundings>,
+                IReadOnlyCollection<QualificationDiscussionHistory>, CancellationToken>(
+                (_, fundings, histories, _) =>
                 {
-                    Id = historyId,
-                    QualificationId = qualificationId,
-                    UserDisplayName = "Rollover System",
-                    Title = "Rollover Funding Decision",
-                    Timestamp = timestamp,
-                    Notes = "FS extended to 06-10-2027",
-                    ActionTypeId = Guid.Parse("00000000-0000-0000-0000-000000000004")
-                }
-            };
+                    persistedFundings = fundings;
+                    persistedHistories = histories;
+                })
+            .Returns(Task.CompletedTask);
 
-            // Act
-            var result = await _service.Submit(candidates, [item], fundings, CancellationToken.None);
+        // Act
+        var result = await _service.Submit([candidate], [item], [], CancellationToken);
 
-            // Assert
-            Assert.True(result);
+        // Assert
+        result.ShouldBeTrue();
+        candidate.RolloverStatus.ShouldBe(RolloverStatus.Excluded);
+        candidate.ExclusionReason.ShouldBe("Bad data");
+        persistedFundings.ShouldBeEmpty();
+        persistedHistories.ShouldNotBeNull();
+        persistedHistories.Count.ShouldBe(1);
+        persistedHistories.Single().Notes.ShouldBe("FS was not extended due to Bad data");
+    }
 
-            Assert.Equal(RolloverStatus.Extended, candidate.RolloverStatus);
-            Assert.Equal(item.ProposedFundingApprovalEndDate.Date, funding.EndDate?.ToDateTime(TimeOnly.MinValue).Date);
-            Assert.Equal(item.Comments, funding.Comments);
-
-            _historyRepository.Verify(h =>
-                h.AddDiscussionHistories(expectedQualificationDiscussionHistories),
-                Times.Once);
-
-            _rolloverRepository.Verify(r => r.DeleteAllWorkflowCandidatesAsync(It.IsAny<CancellationToken>()), Times.Once);
-        }
-
-        // ------------------------------------------------------------
-        // SUCCESS — EXCLUDED STATUS UPDATES CANDIDATE + HISTORY
-        // ------------------------------------------------------------
-        [Fact]
-        public async Task Submit_Excluded_SetsExcluded_AndCreatesHistory()
+    [Fact]
+    public async Task Submit_WhenStatusesAreMixed_CreatesTwoHistoryEntries()
+    {
+        // Arrange
+        var extendedItem = new FundingExtensionItem
         {
-            // Arrange
-            var item = new FundingExtensionItem
-            {
-                Qan = "111",
-                FundingStreamName = "FS",
-                RolloverStatus = "Excluded",
-                ExclusionReason = "Bad data"
-            };
-
-            var candidate = CandidateHelper.BuildCandidate(_fixture, item.Qan, item.FundingStreamName);
-            var funding = new QualificationFundings
-            {
-                QualificationVersionId = candidate.QualificationVersionId,
-                FundingOfferId = candidate.FundingOfferId
-            };
-
-            var candidates = new List<RolloverCandidates> { candidate };
-            var fundings = new List<QualificationFundings> { funding };
-
-            // Act
-            var result = await _service.Submit(candidates, [item], fundings, CancellationToken.None);
-
-            // Assert
-            Assert.True(result);
-
-            Assert.Equal(RolloverStatus.Excluded, candidate.RolloverStatus);
-            Assert.Equal("Bad data", candidate.ExclusionReason);
-
-            _historyRepository.Verify(h =>
-                h.AddDiscussionHistories(It.Is<List<QualificationDiscussionHistory>>(l => l.Count == 1)),
-                Times.Once);
-        }
-
-        // ------------------------------------------------------------
-        // MIXED — EXTENDED + EXCLUDED → TWO HISTORY ENTRIES
-        // ------------------------------------------------------------
-        [Fact]
-        public async Task Submit_MixedStatuses_CreatesTwoHistoryEntries()
+            Qan = "111",
+            FundingStreamName = "FS1",
+            RolloverStatus = "Extended",
+            ProposedFundingApprovalEndDate = new DateTime(2027, 10, 6)
+        };
+        var excludedItem = new FundingExtensionItem
         {
-            // Arrange
-            var item1 = new FundingExtensionItem
-            {
-                Qan = "111",
-                FundingStreamName = "FS1",
-                RolloverStatus = "Extended",
-                ProposedFundingApprovalEndDate = DateTime.UtcNow.AddYears(1)
-            };
-
-            var item2 = new FundingExtensionItem
-            {
-                Qan = "222",
-                FundingStreamName = "FS2",
-                RolloverStatus = "Excluded",
-                ExclusionReason = "Reason"
-            };
-
-            var candidate1 = CandidateHelper.BuildCandidate(_fixture, item1.Qan, item1.FundingStreamName);
-            var candidate2 = CandidateHelper.BuildCandidate(_fixture, item2.Qan, item2.FundingStreamName);
-
-            // Same qualification → grouped together
-            candidate2.QualificationVersion.QualificationId = candidate1.QualificationVersion.QualificationId;
-
-            var funding1 = new QualificationFundings
-            {
-                QualificationVersionId = candidate1.QualificationVersionId,
-                FundingOfferId = candidate1.FundingOfferId
-            };
-
-            var candidates = new List<RolloverCandidates> { candidate1, candidate2 };
-            var fundings = new List<QualificationFundings> { funding1 };
-
-            // Act
-            var result = await _service.Submit(candidates, [item1, item2], fundings, CancellationToken.None);
-
-            // Assert
-            Assert.True(result);
-
-            _historyRepository.Verify(h =>
-                h.AddDiscussionHistories(It.Is<List<QualificationDiscussionHistory>>(l => l.Count == 2)),
-                Times.Once);
-        }
-
-        // ------------------------------------------------------------
-        // NO MATCHING INPUT → NO UPDATES, NO HISTORY
-        // ------------------------------------------------------------
-        [Fact]
-        public async Task Submit_NoMatchingInput_DoesNothing_ReturnsTrue()
+            Qan = "222",
+            FundingStreamName = "FS2",
+            RolloverStatus = "Excluded",
+            ExclusionReason = "Reason"
+        };
+        var extendedCandidate = CandidateHelper.BuildCandidate(
+            _fixture,
+            extendedItem.Qan,
+            extendedItem.FundingStreamName);
+        var excludedCandidate = CandidateHelper.BuildCandidate(
+            _fixture,
+            excludedItem.Qan,
+            excludedItem.FundingStreamName);
+        excludedCandidate.QualificationVersion.QualificationId =
+            extendedCandidate.QualificationVersion.QualificationId;
+        var funding = new QualificationFundings
         {
-            // Arrange
-            var candidate = CandidateHelper.BuildCandidate(_fixture, "111", "FS");
-            var funding = new QualificationFundings
-            {
-                QualificationVersionId = candidate.QualificationVersionId,
-                FundingOfferId = candidate.FundingOfferId
-            };
+            QualificationVersionId = extendedCandidate.QualificationVersionId,
+            FundingOfferId = extendedCandidate.FundingOfferId
+        };
 
-            // Input does not match candidate
-            var item = new FundingExtensionItem
-            {
-                Qan = "XXX",
-                FundingStreamName = "YYY",
-                RolloverStatus = "Extended"
-            };
+        _persistenceRepository
+            .Setup(repository => repository.PersistAsync(
+                It.Is<IReadOnlyCollection<RolloverCandidates>>(values => values.Count == 2),
+                It.Is<IReadOnlyCollection<QualificationFundings>>(values => values.Count == 1),
+                It.Is<IReadOnlyCollection<QualificationDiscussionHistory>>(values => values.Count == 2),
+                CancellationToken))
+            .Returns(Task.CompletedTask);
 
-            // Act
-            var result = await _service.Submit([candidate], [item], [funding], CancellationToken.None);
+        // Act
+        var result = await _service.Submit(
+            [extendedCandidate, excludedCandidate],
+            [extendedItem, excludedItem],
+            [funding],
+            CancellationToken);
 
-            // Assert
-            Assert.True(result);
+        // Assert
+        result.ShouldBeTrue();
+        _persistenceRepository.VerifyAll();
+    }
 
-            Assert.Equal(RolloverStatus.None, candidate.RolloverStatus);
-
-            _historyRepository.Verify(h => h.AddDiscussionHistories(It.IsAny<List<QualificationDiscussionHistory>>()), Times.Once);
-        }
-
-        // ------------------------------------------------------------
-        // EXCEPTION → RETURNS FALSE
-        // ------------------------------------------------------------
-        [Fact]
-        public async Task Submit_ExceptionThrown_ReturnsFalse()
+    [Fact]
+    public async Task Submit_WhenInputDoesNotMatch_PersistsEmptyChangesToCompleteWorkflow()
+    {
+        // Arrange
+        var candidate = CandidateHelper.BuildCandidate(_fixture, "111", "FS");
+        var item = new FundingExtensionItem
         {
-            // Arrange
-            var candidate = CandidateHelper.BuildCandidate(_fixture, "111", "FS");
-            var funding = new QualificationFundings
-            {
-                QualificationVersionId = candidate.QualificationVersionId,
-                FundingOfferId = candidate.FundingOfferId
-            };
+            Qan = "XXX",
+            FundingStreamName = "YYY",
+            RolloverStatus = "Extended"
+        };
 
-            _historyRepository
-                .Setup(h => h.AddDiscussionHistories(It.IsAny<List<QualificationDiscussionHistory>>()))
-                .Throws(new Exception("Boom"));
+        _persistenceRepository
+            .Setup(repository => repository.PersistAsync(
+                It.Is<IReadOnlyCollection<RolloverCandidates>>(values => values.Count == 0),
+                It.Is<IReadOnlyCollection<QualificationFundings>>(values => values.Count == 0),
+                It.Is<IReadOnlyCollection<QualificationDiscussionHistory>>(values => values.Count == 0),
+                CancellationToken))
+            .Returns(Task.CompletedTask);
 
-            // Act
-            var result = await _service.Submit([candidate], [], [funding], CancellationToken.None);
+        // Act
+        var result = await _service.Submit([candidate], [item], [], CancellationToken);
 
-            // Assert
-            Assert.False(result);
-        }
+        // Assert
+        result.ShouldBeTrue();
+        candidate.RolloverStatus.ShouldBe(RolloverStatus.None);
+        _persistenceRepository.VerifyAll();
+    }
 
+    [Fact]
+    public async Task Submit_WhenPersistenceThrows_ReturnsFalse()
+    {
+        // Arrange
+        _persistenceRepository
+            .Setup(repository => repository.PersistAsync(
+                It.IsAny<IReadOnlyCollection<RolloverCandidates>>(),
+                It.IsAny<IReadOnlyCollection<QualificationFundings>>(),
+                It.IsAny<IReadOnlyCollection<QualificationDiscussionHistory>>(),
+                CancellationToken))
+            .ThrowsAsync(new InvalidOperationException("Boom"));
+
+        // Act
+        var result = await _service.Submit([], [], [], CancellationToken);
+
+        // Assert
+        result.ShouldBeFalse();
+        _logger.Verify(
+            logger => logger.Log(
+                LogLevel.Error,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((state, _) =>
+                    state.ToString()!.Contains("Funding-extension processing failed")),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
     }
 }

--- a/src/SFA.DAS.AODP.Application/Commands/Rollover/CreateRolloverWorkflowRunCommandHandler.cs
+++ b/src/SFA.DAS.AODP.Application/Commands/Rollover/CreateRolloverWorkflowRunCommandHandler.cs
@@ -10,12 +10,10 @@ namespace SFA.DAS.AODP.Application.Commands.Rollover
     : IRequestHandler<CreateRolloverWorkflowRunCommand, BaseMediatrResponse<CreateRolloverWorkflowRunCommandResponse>>
     {
         private readonly IRolloverRepository _repository;
-        private readonly IMediator _mediator;
 
-        public CreateRolloverWorkflowRunCommandHandler(IRolloverRepository rolloverRepository, IMediator mediator)
+        public CreateRolloverWorkflowRunCommandHandler(IRolloverRepository rolloverRepository)
         {
             _repository = rolloverRepository;
-            _mediator = mediator;
         }
 
         public async Task<BaseMediatrResponse<CreateRolloverWorkflowRunCommandResponse>> Handle(CreateRolloverWorkflowRunCommand request, CancellationToken cancellationToken)
@@ -29,42 +27,69 @@ namespace SFA.DAS.AODP.Application.Commands.Rollover
                     throw new InvalidOperationException("At least one rollover candidate must be provided.");
                 }
 
-                var candidates = await _repository.GetRolloverCandidatesByIdsAsync(request.RolloverCandidateIds, cancellationToken);
-                if (candidates.Count() != request.RolloverCandidateIds.Count())
+                var p1CheckRequests = request.RolloverCandidateIds
+                    .Select(id => new RolloverCandidateP1CheckRequest(
+                        id,
+                        request.FundingEndDateEligibilityThreshold,
+                        request.OperationalEndDateEligibilityThreshold,
+                        request.MaximumApprovalFundingEndDate))
+                    .ToList();
+
+                var candidatesWithP1Checks =
+                    await _repository.GetRolloverCandidatesWithP1ChecksAsync(
+                        p1CheckRequests,
+                        cancellationToken);
+
+                if (candidatesWithP1Checks.Count != request.RolloverCandidateIds.Count)
                 {
                     throw new InvalidOperationException("One or more rollover candidate IDs are invalid or inactive.");
                 }
 
                 var now = DateTime.UtcNow;
 
-                var workflowrun = RolloverWorkflowRun.Create(request.AcademicYear,
+                var workflowRun = RolloverWorkflowRun.Create(request.AcademicYear,
                     request.SelectionMethod, 
                     request.FundingEndDateEligibilityThreshold,
                     request.OperationalEndDateEligibilityThreshold, 
                     request.MaximumApprovalFundingEndDate, 
                     request.CreatedByUserName!,
                     now);
-                var workflowRunId = await _repository.CreateRolloverWorkflowRunAsync(workflowrun, cancellationToken);
 
-                var workflowCandidates = candidates
-                   .Select(rc => RolloverWorkflowCandidate.Create(
-                       workflowRunId,
-                       rc.Id,
-                       rc.QualificationVersionId,
-                       rc.FundingOfferId,
-                       rc.AcademicYear!,
-                       rc.RolloverRound,
-                       rc.PreviousFundingEndDate ?? now,
-                       rc.NewFundingEndDate,
-                       now));
-                await _repository.CreateRolloverWorkflowCandidatesAsync(workflowCandidates, cancellationToken);
+                var workflowCandidates = candidatesWithP1Checks
+                   .Select(candidateData => RolloverWorkflowCandidate.Create(
+                       workflowRun.Id,
+                       candidateData.Candidate.Id,
+                       candidateData.Candidate.QualificationVersionId,
+                       candidateData.Candidate.FundingOfferId,
+                       candidateData.Candidate.AcademicYear!,
+                       candidateData.Candidate.RolloverRound,
+                       candidateData.Candidate.PreviousFundingEndDate ?? now,
+                       candidateData.Candidate.NewFundingEndDate,
+                       now))
+                   .ToList();
+
+                var workflowCandidatesByRolloverCandidateId = workflowCandidates
+                    .ToDictionary(x => x.RolloverCandidatesId);
+
+                foreach (var candidateData in candidatesWithP1Checks)
+                {
+                    if (workflowCandidatesByRolloverCandidateId.TryGetValue(
+                            candidateData.Candidate.Id,
+                            out var workflowCandidate))
+                    {
+                        workflowCandidate.ProcessP1Checks(candidateData.P1Checks);
+                    }
+                }
 
                 var workflowFundingOffers = request.FundingOfferIds
-                    .Select(foId => RolloverWorkflowRunFundingOffer.Create(workflowRunId, foId))
+                    .Select(foId => RolloverWorkflowRunFundingOffer.Create(workflowRun.Id, foId))
                     .ToList();
-                await _repository.CreateRolloverWorkflowRunFundingOffersAsync(workflowFundingOffers, cancellationToken);
 
-                await _mediator.Send(new UpdateRolloverWorkflowCandidatesAfterP1ChecksCommand(),cancellationToken);
+                var workflowRunId = await _repository.CreateRolloverWorkflowAsync(
+                    workflowRun,
+                    workflowCandidates,
+                    workflowFundingOffers,
+                    cancellationToken);
 
                 response.Value = new CreateRolloverWorkflowRunCommandResponse
                 {

--- a/src/SFA.DAS.AODP.Application/Commands/Rollover/SubmitRolloverExtensionCommandHandler.cs
+++ b/src/SFA.DAS.AODP.Application/Commands/Rollover/SubmitRolloverExtensionCommandHandler.cs
@@ -1,4 +1,6 @@
 ﻿using MediatR;
+using Microsoft.Extensions.Logging;
+using System.Diagnostics;
 using SFA.DAS.AODP.Application.Services.FundingExtension;
 using SFA.DAS.AODP.Data.Repositories.Qualification;
 using SFA.DAS.AODP.Data.Repositories.Rollover;
@@ -12,16 +14,18 @@ namespace SFA.DAS.AODP.Application.Commands.Rollover
         private readonly IRolloverRepository _rolloverRepository;
         private readonly IQualificationFundingsRepository _qualificationFundingsRepository;
         private readonly ISubmitFundingExtensionService _applyFundingExtensionsService;
+        private readonly ILogger<SubmitRolloverExtensionCommandHandler> _logger;
 
         public SubmitRolloverExtensionCommandHandler(
             IRolloverRepository rolloverRepository,
             IQualificationFundingsRepository qualificationFundingsRepository,
-            ISubmitFundingExtensionService applyFundingExtensionsService
-)
+            ISubmitFundingExtensionService applyFundingExtensionsService,
+            ILogger<SubmitRolloverExtensionCommandHandler> logger)
         {
             _rolloverRepository = rolloverRepository;
             _qualificationFundingsRepository = qualificationFundingsRepository;
             _applyFundingExtensionsService = applyFundingExtensionsService;
+            _logger = logger;
         }
 
         public async Task<BaseMediatrResponse<SubmitRolloverExtensionCommandResponse>> Handle(
@@ -29,6 +33,7 @@ namespace SFA.DAS.AODP.Application.Commands.Rollover
             CancellationToken cancellationToken)
         {
             var response = new BaseMediatrResponse<SubmitRolloverExtensionCommandResponse>();
+            var totalStarted = Stopwatch.GetTimestamp();
 
             try
             {
@@ -40,11 +45,20 @@ namespace SFA.DAS.AODP.Application.Commands.Rollover
                     ))
                     .ToList();
 
+                var candidateLoadStarted = Stopwatch.GetTimestamp();
                 var candidates = await _rolloverRepository
                     .LoadRolloverCandidateGraphAsync(keys, cancellationToken);
+                _logger.LogInformation(
+                    "Loaded {CandidateCount} rollover candidates for {RequestedItemCount} submitted items in {ElapsedMilliseconds} ms",
+                    candidates.Count,
+                    request.Items.Count,
+                    Stopwatch.GetElapsedTime(candidateLoadStarted).TotalMilliseconds);
 
                 if (candidates.Count == 0)
                 {
+                    _logger.LogInformation(
+                        "Completed funding-extension submission with no matching candidates in {ElapsedMilliseconds} ms",
+                        Stopwatch.GetElapsedTime(totalStarted).TotalMilliseconds);
                     response.Success = true;
                     response.Value.ResultMessage = "No matching rollover candidates were found.";
                     return response;
@@ -57,25 +71,46 @@ namespace SFA.DAS.AODP.Application.Commands.Rollover
                     .Distinct()
                     .ToList();
 
+                var fundingLoadStarted = Stopwatch.GetTimestamp();
                 var fundings = await _qualificationFundingsRepository
                     .GetRolloverQualificationFundingsAsync(fundingKeys, cancellationToken);
+                _logger.LogInformation(
+                    "Loaded {FundingCount} qualification funding records in {ElapsedMilliseconds} ms",
+                    fundings.Count,
+                    Stopwatch.GetElapsedTime(fundingLoadStarted).TotalMilliseconds);
 
+                var submissionStarted = Stopwatch.GetTimestamp();
                 var success = await _applyFundingExtensionsService.Submit(candidates, request.Items, fundings, cancellationToken);
+                _logger.LogInformation(
+                    "Applied and persisted funding-extension changes with success status {SubmissionSuccess} in {ElapsedMilliseconds} ms",
+                    success,
+                    Stopwatch.GetElapsedTime(submissionStarted).TotalMilliseconds);
 
                 if (!success)
                 {
+                    _logger.LogWarning(
+                        "Funding-extension submission failed after {ElapsedMilliseconds} ms for {RequestedItemCount} submitted items",
+                        Stopwatch.GetElapsedTime(totalStarted).TotalMilliseconds,
+                        request.Items.Count);
                     response.Success = true;
                     response.Value.ResultMessage = "Failed to apply funding extensions.";
                     return response;
                 }
 
-                await _rolloverRepository.SaveChangesAsync(cancellationToken);
-
                 response.Value.ResultMessage = "Funding extensions applied.";
                 response.Success = true;
+                _logger.LogInformation(
+                    "Completed funding-extension submission for {RequestedItemCount} submitted items in {ElapsedMilliseconds} ms",
+                    request.Items.Count,
+                    Stopwatch.GetElapsedTime(totalStarted).TotalMilliseconds);
             }
             catch (Exception ex)
             {
+                _logger.LogError(
+                    ex,
+                    "Funding-extension submission threw an exception after {ElapsedMilliseconds} ms for {RequestedItemCount} submitted items",
+                    Stopwatch.GetElapsedTime(totalStarted).TotalMilliseconds,
+                    request.Items.Count);
                 response.InnerException = ex;
                 response.Success = false;
                 response.ErrorMessage = ex.Message;

--- a/src/SFA.DAS.AODP.Application/Commands/Rollover/SubmitRolloverExtensionCommandHandler.cs
+++ b/src/SFA.DAS.AODP.Application/Commands/Rollover/SubmitRolloverExtensionCommandHandler.cs
@@ -46,8 +46,8 @@ namespace SFA.DAS.AODP.Application.Commands.Rollover
                     .ToList();
 
                 var candidateLoadStarted = Stopwatch.GetTimestamp();
-                var candidates = await _rolloverRepository
-                    .LoadRolloverCandidateGraphAsync(keys, cancellationToken);
+                var candidates = await _rolloverRepository.LoadRolloverCandidateGraphAsync(keys, cancellationToken);
+                
                 _logger.LogInformation(
                     "Loaded {CandidateCount} rollover candidates for {RequestedItemCount} submitted items in {ElapsedMilliseconds} ms",
                     candidates.Count,
@@ -59,6 +59,7 @@ namespace SFA.DAS.AODP.Application.Commands.Rollover
                     _logger.LogInformation(
                         "Completed funding-extension submission with no matching candidates in {ElapsedMilliseconds} ms",
                         Stopwatch.GetElapsedTime(totalStarted).TotalMilliseconds);
+                    
                     response.Success = true;
                     response.Value.ResultMessage = "No matching rollover candidates were found.";
                     return response;
@@ -74,6 +75,7 @@ namespace SFA.DAS.AODP.Application.Commands.Rollover
                 var fundingLoadStarted = Stopwatch.GetTimestamp();
                 var fundings = await _qualificationFundingsRepository
                     .GetRolloverQualificationFundingsAsync(fundingKeys, cancellationToken);
+                
                 _logger.LogInformation(
                     "Loaded {FundingCount} qualification funding records in {ElapsedMilliseconds} ms",
                     fundings.Count,
@@ -81,6 +83,7 @@ namespace SFA.DAS.AODP.Application.Commands.Rollover
 
                 var submissionStarted = Stopwatch.GetTimestamp();
                 var success = await _applyFundingExtensionsService.Submit(candidates, request.Items, fundings, cancellationToken);
+                
                 _logger.LogInformation(
                     "Applied and persisted funding-extension changes with success status {SubmissionSuccess} in {ElapsedMilliseconds} ms",
                     success,
@@ -92,6 +95,7 @@ namespace SFA.DAS.AODP.Application.Commands.Rollover
                         "Funding-extension submission failed after {ElapsedMilliseconds} ms for {RequestedItemCount} submitted items",
                         Stopwatch.GetElapsedTime(totalStarted).TotalMilliseconds,
                         request.Items.Count);
+                    
                     response.Success = true;
                     response.Value.ResultMessage = "Failed to apply funding extensions.";
                     return response;
@@ -99,6 +103,7 @@ namespace SFA.DAS.AODP.Application.Commands.Rollover
 
                 response.Value.ResultMessage = "Funding extensions applied.";
                 response.Success = true;
+                
                 _logger.LogInformation(
                     "Completed funding-extension submission for {RequestedItemCount} submitted items in {ElapsedMilliseconds} ms",
                     request.Items.Count,
@@ -111,6 +116,7 @@ namespace SFA.DAS.AODP.Application.Commands.Rollover
                     "Funding-extension submission threw an exception after {ElapsedMilliseconds} ms for {RequestedItemCount} submitted items",
                     Stopwatch.GetElapsedTime(totalStarted).TotalMilliseconds,
                     request.Items.Count);
+                
                 response.InnerException = ex;
                 response.Success = false;
                 response.ErrorMessage = ex.Message;

--- a/src/SFA.DAS.AODP.Application/Commands/Rollover/UpdateRolloverWorkflowCandidatesAfterP1ChecksCommandHandler.cs
+++ b/src/SFA.DAS.AODP.Application/Commands/Rollover/UpdateRolloverWorkflowCandidatesAfterP1ChecksCommandHandler.cs
@@ -1,4 +1,5 @@
 ﻿using MediatR;
+using SFA.DAS.AODP.Data.Entities.Rollover;
 using SFA.DAS.AODP.Data.Repositories.Rollover;
 
 namespace SFA.DAS.AODP.Application.Commands.Rollover;
@@ -17,18 +18,30 @@ public class UpdateRolloverWorkflowCandidatesAfterP1ChecksCommandHandler : IRequ
         var response = new BaseMediatrResponse<EmptyResponse>();
         try
         {
-            var p1ValidationCheckData = await _rolloverRepository.GetRolloverWorkflowCandidatesP1ChecksAsync(cancellationToken);
-
             var candidates = await _rolloverRepository.GetAllRolloverWorkflowCandidatesAsync(cancellationToken);
 
-            var candidatesById = candidates.ToDictionary(x => x.Id);
+            var p1CheckRequests = candidates
+                .Select(candidate => new RolloverCandidateP1CheckRequest(
+                    candidate.RolloverCandidatesId,
+                    candidate.RolloverWorkflowRun.FundingEndDateEligibilityThreshold,
+                    candidate.RolloverWorkflowRun.OperationalEndDateEligibilityThreshold,
+                    candidate.RolloverWorkflowRun.MaximumApprovalFundingEndDate))
+                .ToList();
+
+            var candidatesWithP1Checks =
+                await _rolloverRepository.GetRolloverCandidatesWithP1ChecksAsync(
+                    p1CheckRequests,
+                    cancellationToken);
+
+            var checksByRolloverCandidateId = candidatesWithP1Checks
+                .ToDictionary(x => x.Candidate.Id, x => x.P1Checks);
             var hasUpdates = false;
 
-            foreach (var check in p1ValidationCheckData)
+            foreach (var candidate in candidates)
             {
-                if (!candidatesById.TryGetValue(
-                        check.WorkflowCandidateId,
-                        out var candidate))
+                if (!checksByRolloverCandidateId.TryGetValue(
+                        candidate.RolloverCandidatesId,
+                        out var check))
                 {
                     continue;
                 }

--- a/src/SFA.DAS.AODP.Application/Commands/Rollover/ValidateRolloverExtensionCommandHandler.cs
+++ b/src/SFA.DAS.AODP.Application/Commands/Rollover/ValidateRolloverExtensionCommandHandler.cs
@@ -1,4 +1,5 @@
 ﻿using MediatR;
+using Microsoft.Extensions.Logging;
 using SFA.DAS.AODP.Application.Constants;
 using SFA.DAS.AODP.Application.Exceptions;
 using SFA.DAS.AODP.Application.Services.Export;
@@ -8,6 +9,7 @@ using SFA.DAS.AODP.Data.Exceptions;
 using SFA.DAS.AODP.Data.Repositories.Rollover;
 using SFA.DAS.AODP.Infrastructure.Extensions;
 using SFA.DAS.AODP.Models.Rollover;
+using System.Diagnostics;
 using System.Text;
 
 namespace SFA.DAS.AODP.Application.Commands.Rollover
@@ -19,17 +21,20 @@ namespace SFA.DAS.AODP.Application.Commands.Rollover
         private readonly IRolloverFundingExtensionValidator _rolloverFundingExtensionValidator;
         private readonly IFundingExtensionCandidatesCsvBuilder _rolloverWorkflowCandidatesCsvBuilder;
         private readonly IFundingExtensionProjectionService _fundingExtensionProjectionService;
+        private readonly ILogger<ValidateRolloverExtensionCommandHandler> _logger;
 
         public ValidateRolloverExtensionCommandHandler(
             IRolloverRepository rolloverRepository, 
             IRolloverFundingExtensionValidator rolloverFundingExtensionValidator, 
             IFundingExtensionCandidatesCsvBuilder rolloverWorkflowCandidatesCsvBuilder,
-            IFundingExtensionProjectionService fundingExtensionProjectionService)
+            IFundingExtensionProjectionService fundingExtensionProjectionService,
+            ILogger<ValidateRolloverExtensionCommandHandler> logger)
         {
             _rolloverRepository = rolloverRepository;
             _rolloverFundingExtensionValidator = rolloverFundingExtensionValidator;
             _rolloverWorkflowCandidatesCsvBuilder = rolloverWorkflowCandidatesCsvBuilder;
             _fundingExtensionProjectionService = fundingExtensionProjectionService;
+            _logger = logger;
         }
 
         public async Task<BaseMediatrResponse<ValidateRolloverExtensionCommandResponse>> Handle(
@@ -37,11 +42,16 @@ namespace SFA.DAS.AODP.Application.Commands.Rollover
             CancellationToken cancellationToken)
         {
             var response = new BaseMediatrResponse<ValidateRolloverExtensionCommandResponse>();
+            var totalStarted = Stopwatch.GetTimestamp();
+            var candidateCount = request.RolloverCandidates?.Count ?? 0;
 
             try
             {
                 if (request.RolloverCandidates == null || request.RolloverCandidates.Count == 0)
                 {
+                    _logger.LogInformation(
+                        "Completed rollover candidate validation with no candidates in {ElapsedMilliseconds} ms",
+                        Stopwatch.GetElapsedTime(totalStarted).TotalMilliseconds);
                     return GeneralFailureResponse("No rollover candidates were provided for validation.");
                 }
 
@@ -49,11 +59,22 @@ namespace SFA.DAS.AODP.Application.Commands.Rollover
                     .Select(x => new CandidateKey(x.Qan, x.FundingStreamName))
                     .ToHashSet();
 
+                var contextLoadStarted = Stopwatch.GetTimestamp();
                 var validationContext = await _rolloverRepository
                     .GetFundingExtensionValidationContextAsync(incomingKeys, cancellationToken);
+                _logger.LogInformation(
+                    "Loaded rollover validation context for {CandidateCount} candidates in {ElapsedMilliseconds} ms",
+                    candidateCount,
+                    Stopwatch.GetElapsedTime(contextLoadStarted).TotalMilliseconds);
 
+                var validationStarted = Stopwatch.GetTimestamp();
                 var validationResult = _rolloverFundingExtensionValidator
                     .Validate(request.RolloverCandidates, validationContext, cancellationToken);
+                _logger.LogInformation(
+                    "Validated {CandidateCount} rollover candidates with {FailedCandidateCount} failures in {ElapsedMilliseconds} ms",
+                    candidateCount,
+                    validationResult.FailedCandidateCount,
+                    Stopwatch.GetElapsedTime(validationStarted).TotalMilliseconds);
 
                 var validationResponse = new ValidateRolloverExtensionCommandResponse
                 {
@@ -62,13 +83,23 @@ namespace SFA.DAS.AODP.Application.Commands.Rollover
 
                 if (!validationResult.IsValid)
                 {
+                    var workflowRunLoadStarted = Stopwatch.GetTimestamp();
                     var latestRunId = await _rolloverRepository.GetLatestWorkflowRunIdAsync(cancellationToken);
+                    _logger.LogInformation(
+                        "Loaded the latest rollover workflow run in {ElapsedMilliseconds} ms",
+                        Stopwatch.GetElapsedTime(workflowRunLoadStarted).TotalMilliseconds);
 
                     if (latestRunId == Guid.Empty)
                         throw new InvalidOperationException("No workflow runs exist");
 
+                    var exportLoadStarted = Stopwatch.GetTimestamp();
                     var exportRows = await _rolloverRepository.GetRolloverWorkflowCandidatesByRunId(latestRunId.Value, cancellationToken);
+                    _logger.LogInformation(
+                        "Loaded {ExportRowCount} rollover export rows in {ElapsedMilliseconds} ms",
+                        exportRows.Count,
+                        Stopwatch.GetElapsedTime(exportLoadStarted).TotalMilliseconds);
 
+                    var failureResponseStarted = Stopwatch.GetTimestamp();
                     var exportLookup = exportRows.ToDictionary(
                         x => new CandidateKey(x.QAN, x.FundingStreamName));
 
@@ -103,28 +134,59 @@ namespace SFA.DAS.AODP.Application.Commands.Rollover
 
                     response.Value = validationResponse;
                     response.Success = true;
+                    _logger.LogInformation(
+                        "Built rollover validation failure response with {MissingCandidateCount} missing candidates in {ElapsedMilliseconds} ms; total validation time was {TotalElapsedMilliseconds} ms",
+                        missingCandidates.Count,
+                        Stopwatch.GetElapsedTime(failureResponseStarted).TotalMilliseconds,
+                        Stopwatch.GetElapsedTime(totalStarted).TotalMilliseconds);
                     return response;
                 }
 
+                var statusLoadStarted = Stopwatch.GetTimestamp();
                 var dbCandidatesStatus = await _rolloverRepository.GetRolloverCandidatesStatusAsync(cancellationToken);
+                _logger.LogInformation(
+                    "Loaded {CandidateStatusCount} rollover candidate statuses in {ElapsedMilliseconds} ms",
+                    dbCandidatesStatus.Count,
+                    Stopwatch.GetElapsedTime(statusLoadStarted).TotalMilliseconds);
 
+                var projectionStarted = Stopwatch.GetTimestamp();
                 validationResponse.ValidationSuccessSummary = _fundingExtensionProjectionService.ProjectSummary(dbCandidatesStatus, request.RolloverCandidates);
+                _logger.LogInformation(
+                    "Projected rollover validation summary in {ElapsedMilliseconds} ms",
+                    Stopwatch.GetElapsedTime(projectionStarted).TotalMilliseconds);
 
                 response.Value = validationResponse;
                 response.Success = true;
+                _logger.LogInformation(
+                    "Completed rollover candidate validation for {CandidateCount} candidates in {ElapsedMilliseconds} ms",
+                    candidateCount,
+                    Stopwatch.GetElapsedTime(totalStarted).TotalMilliseconds);
             }
-            catch (RecordLockedException)
+            catch (RecordLockedException exception)
             {
+                _logger.LogWarning(
+                    exception,
+                    "Rollover candidate validation encountered a locked record after {ElapsedMilliseconds} ms",
+                    Stopwatch.GetElapsedTime(totalStarted).TotalMilliseconds);
                 response.Success = false;
                 response.InnerException = new LockedRecordException();
             }
             catch (NoForeignKeyException ex)
             {
+                _logger.LogWarning(
+                    ex,
+                    "Rollover candidate validation encountered a missing dependency after {ElapsedMilliseconds} ms",
+                    Stopwatch.GetElapsedTime(totalStarted).TotalMilliseconds);
                 response.Success = false;
                 response.InnerException = new DependantNotFoundException(ex.ForeignKey);
             }
             catch (Exception ex)
             {
+                _logger.LogError(
+                    ex,
+                    "Rollover candidate validation failed after {ElapsedMilliseconds} ms for {CandidateCount} candidates",
+                    Stopwatch.GetElapsedTime(totalStarted).TotalMilliseconds,
+                    candidateCount);
                 response.Success = false;
                 response.ErrorMessage = ex.Message;
                 response.InnerException = ex;

--- a/src/SFA.DAS.AODP.Application/Queries/Rollover/GetRolloverStartSummaryQueryHandler.cs
+++ b/src/SFA.DAS.AODP.Application/Queries/Rollover/GetRolloverStartSummaryQueryHandler.cs
@@ -17,8 +17,6 @@ public class GetRolloverStartSummaryQueryHandler(IRolloverRepository repository,
         {
             var currentAcademicYear = academicYearService.GetCurrentAcademicYear();
             
-            var summary = await repository.GetRolloverStartSummaryAsync(currentAcademicYear, cancellationToken);
-
             var result = await repository.GetRolloverStartSummaryAsync(currentAcademicYear, cancellationToken);
 
             if (result != null) 

--- a/src/SFA.DAS.AODP.Application/Services/FundingExtension/SubmitFundingExtensionService.cs
+++ b/src/SFA.DAS.AODP.Application/Services/FundingExtension/SubmitFundingExtensionService.cs
@@ -1,5 +1,6 @@
 ﻿using SFA.DAS.AODP.Application.Commands.Rollover;
 using SFA.DAS.AODP.Application.Constants;
+using SFA.DAS.AODP.Data.Context;
 using SFA.DAS.AODP.Data.Entities.Qualification;
 using SFA.DAS.AODP.Data.Entities.Rollover;
 using SFA.DAS.AODP.Data.Repositories.Qualification;
@@ -16,15 +17,17 @@ namespace SFA.DAS.AODP.Application.Services.FundingExtension
         private readonly IQualificationDiscussionHistoryRepository _qualificationDiscussionHistoryRepository;
         private readonly ISystemClockService _clockService;
         private readonly IGuidProvider _guidProvider;
+        private readonly IApplicationDbContext _dbContext;
         private Guid RolloverExtendedActionTypeId = Guid.Parse("00000000-0000-0000-0000-000000000004");
         private Guid RolloverNotExtendedActionTypeId = Guid.Parse("00000000-0000-0000-0000-000000000005");
 
-        public SubmitFundingExtensionService(IRolloverRepository rolloverRepository, IQualificationDiscussionHistoryRepository qualificationDiscussionHistoryRepository, ISystemClockService clockService, IGuidProvider guidProvider)
+        public SubmitFundingExtensionService(IRolloverRepository rolloverRepository, IQualificationDiscussionHistoryRepository qualificationDiscussionHistoryRepository, ISystemClockService clockService, IGuidProvider guidProvider, IApplicationDbContext dbContext)
         {
             _rolloverRepository = rolloverRepository;
             _qualificationDiscussionHistoryRepository = qualificationDiscussionHistoryRepository;
             _clockService = clockService;
             _guidProvider = guidProvider;
+            _dbContext = dbContext;
         }
 
         public async Task<bool> Submit(
@@ -33,6 +36,8 @@ namespace SFA.DAS.AODP.Application.Services.FundingExtension
             List<QualificationFundings> fundings,
             CancellationToken cancellationToken)
         {
+            await using var transaction = await _dbContext.StartTransactionAsync();
+
             try
             {
                 ApplyCandidateAndFundingUpdates(candidates, inputItems, fundings);
@@ -41,10 +46,13 @@ namespace SFA.DAS.AODP.Application.Services.FundingExtension
 
                 await _rolloverRepository.DeleteAllWorkflowCandidatesAsync(cancellationToken);
 
+                await transaction.CommitAsync(cancellationToken);
+
                 return true;
             }
             catch
             {
+                await transaction.RollbackAsync(cancellationToken);
                 return false;
             }
         }

--- a/src/SFA.DAS.AODP.Application/Services/FundingExtension/SubmitFundingExtensionService.cs
+++ b/src/SFA.DAS.AODP.Application/Services/FundingExtension/SubmitFundingExtensionService.cs
@@ -1,177 +1,222 @@
-﻿using SFA.DAS.AODP.Application.Commands.Rollover;
+using SFA.DAS.AODP.Application.Commands.Rollover;
 using SFA.DAS.AODP.Application.Constants;
-using SFA.DAS.AODP.Data.Context;
+using Microsoft.Extensions.Logging;
+using System.Diagnostics;
 using SFA.DAS.AODP.Data.Entities.Qualification;
 using SFA.DAS.AODP.Data.Entities.Rollover;
-using SFA.DAS.AODP.Data.Repositories.Qualification;
-using SFA.DAS.AODP.Data.Repositories.Rollover;
+using SFA.DAS.AODP.Data.Repositories.FundingExtension;
 using SFA.DAS.AODP.Infrastructure.Extensions;
 using SFA.DAS.AODP.Infrastructure.Services.Interfaces;
 using SFA.DAS.AODP.Models.Rollover;
 
-namespace SFA.DAS.AODP.Application.Services.FundingExtension
+namespace SFA.DAS.AODP.Application.Services.FundingExtension;
+
+public class SubmitFundingExtensionService : ISubmitFundingExtensionService
 {
-    public class SubmitFundingExtensionService :ISubmitFundingExtensionService
+    private static readonly Guid RolloverExtendedActionTypeId =
+        Guid.Parse("00000000-0000-0000-0000-000000000004");
+
+    private static readonly Guid RolloverNotExtendedActionTypeId =
+        Guid.Parse("00000000-0000-0000-0000-000000000005");
+
+    private readonly IFundingExtensionPersistenceRepository _persistenceRepository;
+    private readonly ISystemClockService _clockService;
+    private readonly IGuidProvider _guidProvider;
+    private readonly ILogger<SubmitFundingExtensionService> _logger;
+
+    public SubmitFundingExtensionService(
+        IFundingExtensionPersistenceRepository persistenceRepository,
+        ISystemClockService clockService,
+        IGuidProvider guidProvider,
+        ILogger<SubmitFundingExtensionService> logger)
     {
-        private readonly IRolloverRepository _rolloverRepository;
-        private readonly IQualificationDiscussionHistoryRepository _qualificationDiscussionHistoryRepository;
-        private readonly ISystemClockService _clockService;
-        private readonly IGuidProvider _guidProvider;
-        private readonly IApplicationDbContext _dbContext;
-        private Guid RolloverExtendedActionTypeId = Guid.Parse("00000000-0000-0000-0000-000000000004");
-        private Guid RolloverNotExtendedActionTypeId = Guid.Parse("00000000-0000-0000-0000-000000000005");
+        _persistenceRepository = persistenceRepository;
+        _clockService = clockService;
+        _guidProvider = guidProvider;
+        _logger = logger;
+    }
 
-        public SubmitFundingExtensionService(IRolloverRepository rolloverRepository, IQualificationDiscussionHistoryRepository qualificationDiscussionHistoryRepository, ISystemClockService clockService, IGuidProvider guidProvider, IApplicationDbContext dbContext)
+    public async Task<bool> Submit(
+        List<RolloverCandidates> candidates,
+        List<FundingExtensionItem> inputItems,
+        List<QualificationFundings> fundings,
+        CancellationToken cancellationToken)
+    {
+        var totalStarted = Stopwatch.GetTimestamp();
+
+        try
         {
-            _rolloverRepository = rolloverRepository;
-            _qualificationDiscussionHistoryRepository = qualificationDiscussionHistoryRepository;
-            _clockService = clockService;
-            _guidProvider = guidProvider;
-            _dbContext = dbContext;
-        }
-
-        public async Task<bool> Submit(
-            List<RolloverCandidates> candidates,
-            List<FundingExtensionItem> inputItems,
-            List<QualificationFundings> fundings,
-            CancellationToken cancellationToken)
-        {
-            await using var transaction = await _dbContext.StartTransactionAsync();
-
-            try
-            {
-                ApplyCandidateAndFundingUpdates(candidates, inputItems, fundings);
-
-                await CreateDiscussionHistoriesAsync(candidates, fundings);
-
-                await _rolloverRepository.DeleteAllWorkflowCandidatesAsync(cancellationToken);
-
-                await transaction.CommitAsync(cancellationToken);
-
-                return true;
-            }
-            catch
-            {
-                await transaction.RollbackAsync(cancellationToken);
-                return false;
-            }
-        }
-
-        private static void ApplyCandidateAndFundingUpdates(
-            List<RolloverCandidates> candidates,
-            List<FundingExtensionItem> inputItems,
-            List<QualificationFundings> fundings)
-        {
+            var lookupStarted = Stopwatch.GetTimestamp();
             var inputLookup = inputItems.ToDictionary(
                 x => (x.Qan!, x.FundingStreamName!));
 
             var fundingLookup = fundings.ToDictionary(
                 x => (x.QualificationVersionId, x.FundingOfferId));
+            _logger.LogInformation(
+                "Built funding-extension input and funding lookups for {InputCount} inputs and {FundingCount} fundings in {ElapsedMilliseconds} ms",
+                inputItems.Count,
+                fundings.Count,
+                Stopwatch.GetElapsedTime(lookupStarted).TotalMilliseconds);
 
-            foreach (var c in candidates)
-            {
-                if (!inputLookup.TryGetValue(
-                    (c.QualificationVersion.Qualification.Qan, c.FundingOffer.Name),
-                    out var input))
-                {
-                    continue;
-                }
+            var updateStarted = Stopwatch.GetTimestamp();
+            var (updatedCandidates, updatedFundings) = ApplyCandidateAndFundingUpdates(
+                candidates,
+                inputLookup,
+                fundingLookup);
+            _logger.LogInformation(
+                "Prepared {CandidateUpdateCount} candidate updates and {FundingUpdateCount} funding updates in {ElapsedMilliseconds} ms",
+                updatedCandidates.Count,
+                updatedFundings.Count,
+                Stopwatch.GetElapsedTime(updateStarted).TotalMilliseconds);
 
-                var status = RolloverStatusInfo.FromCsv(input.RolloverStatus ?? string.Empty);
+            var historyStarted = Stopwatch.GetTimestamp();
+            var historyEntries = CreateDiscussionHistories(updatedCandidates, fundingLookup);
+            _logger.LogInformation(
+                "Created {HistoryCount} rollover discussion-history records in {ElapsedMilliseconds} ms",
+                historyEntries.Count,
+                Stopwatch.GetElapsedTime(historyStarted).TotalMilliseconds);
 
-                switch (status)
-                {
-                    case RolloverStatus.Extended:
-                        c.SetExtended(input.ProposedFundingApprovalEndDate);
+            var persistenceStarted = Stopwatch.GetTimestamp();
+            await _persistenceRepository.PersistAsync(
+                updatedCandidates,
+                updatedFundings,
+                historyEntries,
+                cancellationToken);
+            _logger.LogInformation(
+                "Persisted funding-extension changes in {ElapsedMilliseconds} ms",
+                Stopwatch.GetElapsedTime(persistenceStarted).TotalMilliseconds);
 
-                        if (fundingLookup.TryGetValue(
-                            (c.QualificationVersionId, c.FundingOfferId),
-                            out var funding))
-                        {
-                            funding.EndDate = DateOnly.FromDateTime(input.ProposedFundingApprovalEndDate);
-                            funding.Comments = input.Comments;
-                        }
-                        break;
+            _logger.LogInformation(
+                "Completed funding-extension processing in {ElapsedMilliseconds} ms",
+                Stopwatch.GetElapsedTime(totalStarted).TotalMilliseconds);
 
-                    case RolloverStatus.Excluded:
-                        c.SetExcluded(input.ExclusionReason!);
-                        break;
-
-                    default:
-                        throw new InvalidOperationException(
-                            $"Unexpected rollover status: {input.RolloverStatus}");
-                }
-            }
+            return true;
         }
+        catch (Exception exception)
+        {
+            _logger.LogError(
+                exception,
+                "Funding-extension processing failed after {ElapsedMilliseconds} ms for {CandidateCount} candidates",
+                Stopwatch.GetElapsedTime(totalStarted).TotalMilliseconds,
+                candidates.Count);
+            return false;
+        }
+    }
 
-        private async Task CreateDiscussionHistoriesAsync(
+    private static (List<RolloverCandidates> Candidates, List<QualificationFundings> Fundings)
+        ApplyCandidateAndFundingUpdates(
             List<RolloverCandidates> candidates,
-            List<QualificationFundings> fundings)
+            IReadOnlyDictionary<(string Qan, string FundingStreamName), FundingExtensionItem> inputLookup,
+            IReadOnlyDictionary<(Guid QualificationVersionId, Guid FundingOfferId), QualificationFundings> fundingLookup)
+    {
+        var updatedCandidates = new List<RolloverCandidates>();
+        var updatedFundings = new List<QualificationFundings>();
+
+        foreach (var candidate in candidates)
         {
-            var historyEntries = new List<QualificationDiscussionHistory>();
-
-            var groups = candidates
-                .GroupBy(c => c.QualificationVersion.QualificationId);
-
-            foreach (var group in groups)
+            if (!inputLookup.TryGetValue(
+                    (candidate.QualificationVersion.Qualification.Qan, candidate.FundingOffer.Name),
+                    out var input))
             {
-                var qualificationId = group.Key;
-
-                var extended = group
-                    .Where(c => c.RolloverStatus == RolloverStatus.Extended)
-                    .ToList();
-
-                var excluded = group
-                    .Where(c => c.RolloverStatus == RolloverStatus.Excluded)
-                    .ToList();
-
-                if (extended.Count > 0)
-                {
-                    var lines = extended.Select(c =>
-                    {
-                        var f = fundings.FirstOrDefault(x =>
-                            x.QualificationVersionId == c.QualificationVersionId &&
-                            x.FundingOfferId == c.FundingOfferId);
-
-                        var endDate = f?.EndDate.ToFundingEndDateFormat();
-
-                        return $"{c.FundingOffer.Name} extended to {endDate}";
-                    });
-
-                    var notes = string.Join("\n", lines);
-
-                    historyEntries.Add(CreateDiscussionHistoryEntry(notes, RolloverExtendedActionTypeId, qualificationId));
-                }
-
-                if (excluded.Count > 0)
-                {
-                    var lines = excluded.Select(c =>
-                        $"{c.FundingOffer.Name} was not extended due to {c.ExclusionReason}");
-
-                    var notes = string.Join("\n", lines);
-
-                    historyEntries.Add(CreateDiscussionHistoryEntry(notes, RolloverNotExtendedActionTypeId, qualificationId));
-                }
+                continue;
             }
 
-            _qualificationDiscussionHistoryRepository.AddDiscussionHistories(historyEntries);
+            var status = RolloverStatusInfo.FromCsv(input.RolloverStatus ?? string.Empty);
+
+            switch (status)
+            {
+                case RolloverStatus.Extended:
+                    candidate.SetExtended(input.ProposedFundingApprovalEndDate);
+
+                    if (fundingLookup.TryGetValue(
+                            (candidate.QualificationVersionId, candidate.FundingOfferId),
+                            out var funding))
+                    {
+                        funding.EndDate = DateOnly.FromDateTime(input.ProposedFundingApprovalEndDate);
+                        funding.Comments = input.Comments;
+                        updatedFundings.Add(funding);
+                    }
+
+                    break;
+
+                case RolloverStatus.Excluded:
+                    candidate.SetExcluded(input.ExclusionReason!);
+                    break;
+
+                default:
+                    throw new InvalidOperationException(
+                        $"Unexpected rollover status: {input.RolloverStatus}");
+            }
+
+            updatedCandidates.Add(candidate);
         }
 
-        private QualificationDiscussionHistory CreateDiscussionHistoryEntry(
-            string note, 
-            Guid actionTypeId,
-            Guid qualificationId)
+        return (updatedCandidates, updatedFundings);
+    }
+
+    private List<QualificationDiscussionHistory> CreateDiscussionHistories(
+        IReadOnlyCollection<RolloverCandidates> candidates,
+        IReadOnlyDictionary<(Guid QualificationVersionId, Guid FundingOfferId), QualificationFundings> fundingLookup)
+    {
+        var historyEntries = new List<QualificationDiscussionHistory>();
+
+        foreach (var group in candidates.GroupBy(c => c.QualificationVersion.QualificationId))
         {
-            return new QualificationDiscussionHistory
+            var extended = group
+                .Where(c => c.RolloverStatus == RolloverStatus.Extended)
+                .ToList();
+
+            var excluded = group
+                .Where(c => c.RolloverStatus == RolloverStatus.Excluded)
+                .ToList();
+
+            if (extended.Count > 0)
             {
-                Id = _guidProvider.NewGuid(),
-                Title = "Rollover Funding Decision",
-                UserDisplayName = "Rollover System",
-                ActionTypeId = actionTypeId,
-                QualificationId = qualificationId,
-                Notes = note,
-                Timestamp = _clockService.UtcNow
-            };
+                var lines = extended.Select(candidate =>
+                {
+                    fundingLookup.TryGetValue(
+                        (candidate.QualificationVersionId, candidate.FundingOfferId),
+                        out var funding);
+
+                    var endDate = funding?.EndDate.ToFundingEndDateFormat();
+                    return $"{candidate.FundingOffer.Name} extended to {endDate}";
+                });
+
+                historyEntries.Add(CreateDiscussionHistoryEntry(
+                    string.Join("\n", lines),
+                    RolloverExtendedActionTypeId,
+                    group.Key));
+            }
+
+            if (excluded.Count > 0)
+            {
+                var lines = excluded.Select(candidate =>
+                    $"{candidate.FundingOffer.Name} was not extended due to {candidate.ExclusionReason}");
+
+                historyEntries.Add(CreateDiscussionHistoryEntry(
+                    string.Join("\n", lines),
+                    RolloverNotExtendedActionTypeId,
+                    group.Key));
+            }
         }
+
+        return historyEntries;
+    }
+
+    private QualificationDiscussionHistory CreateDiscussionHistoryEntry(
+        string note,
+        Guid actionTypeId,
+        Guid qualificationId)
+    {
+        return new QualificationDiscussionHistory
+        {
+            Id = _guidProvider.NewGuid(),
+            Title = "Rollover Funding Decision",
+            UserDisplayName = "Rollover System",
+            ActionTypeId = actionTypeId,
+            QualificationId = qualificationId,
+            Notes = note,
+            Timestamp = _clockService.UtcNow
+        };
     }
 }

--- a/src/SFA.DAS.AODP.Data.Tests/Entities/Rollover/RolloverWorkflowRunTests.cs
+++ b/src/SFA.DAS.AODP.Data.Tests/Entities/Rollover/RolloverWorkflowRunTests.cs
@@ -31,7 +31,7 @@ public class RolloverWorkflowRunTests
         Assert.Empty(result.FundingOffers);
         Assert.Empty(result.Candidates);
         Assert.Empty(result.Filters);
-        Assert.Equal(Guid.Empty, result.Id);
+        Assert.NotEqual(Guid.Empty, result.Id);
     }
 
     [Fact]

--- a/src/SFA.DAS.AODP.Data.Tests/Repositories/Qualifications/QualificationFundingRepositoryTests.cs
+++ b/src/SFA.DAS.AODP.Data.Tests/Repositories/Qualifications/QualificationFundingRepositoryTests.cs
@@ -8,6 +8,7 @@ using SFA.DAS.AODP.Data.Entities.Qualification;
 using SFA.DAS.AODP.Data.Repositories.Qualification;
 using SFA.DAS.AODP.Models.Rollover;
 using SFA.DAS.AODP.Testing.Helpers;
+using Shouldly;
 using static SFA.DAS.AODP.Application.Queries.Qualification.GetQualificationVersionsForQualificationByReferenceQueryResponse;
 using QualificationVersions = SFA.DAS.AODP.Data.Entities.Qualification.QualificationVersions;
 
@@ -152,6 +153,22 @@ namespace SFA.DAS.AODP.Data.UnitTests.Repositories
             Assert.Contains(result, x => x.Id == fundingList[0].Id);
             Assert.Contains(result, x => x.Id == fundingList[1].Id);
             Assert.DoesNotContain(result, x => x.Id == fundingList[2].Id);
+        }
+
+        [Fact]
+        public async Task GetRolloverQualificationFundingsAsync_WhenKeysAreEmpty_ReturnsEmptyCollection()
+        {
+            // Arrange
+            using var context = CreateInMemoryContext();
+            var repo = new QualificationFundingsRepository(context);
+
+            // Act
+            var result = await repo.GetRolloverQualificationFundingsAsync(
+                [],
+                TestContext.Current.CancellationToken);
+
+            // Assert
+            result.ShouldBeEmpty();
         }
 
         private List<QualificationFundings> CreateFundings(int count, Guid versionId)

--- a/src/SFA.DAS.AODP.Data.Tests/Repositories/Rollover/RemovePreviousWorkflowCandidatesTests.cs
+++ b/src/SFA.DAS.AODP.Data.Tests/Repositories/Rollover/RemovePreviousWorkflowCandidatesTests.cs
@@ -1,3 +1,4 @@
+using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using SFA.DAS.AODP.Data.Context;
 using SFA.DAS.AODP.Data.Repositories.Rollover;
@@ -9,11 +10,16 @@ public class RemovePreviousWorkflowCandidatesTests
 {
     private static ApplicationDbContext CreateDb(string name)
     {
+        var connection = new SqliteConnection("DataSource=:memory:");
+        connection.Open();
         var options = new DbContextOptionsBuilder<ApplicationDbContext>()
-            .UseInMemoryDatabase(name + "_" + Guid.NewGuid())
+            .UseSqlite(connection)
             .Options;
 
-        return new ApplicationDbContext(options);
+        var context = new ApplicationDbContext(options);
+        context.Database.EnsureCreated();
+        context.Database.ExecuteSqlRaw("PRAGMA foreign_keys = OFF;");
+        return context;
     }
 
     [Fact]

--- a/src/SFA.DAS.AODP.Data.Tests/Repositories/Rollover/RolloverRepositoryTests.cs
+++ b/src/SFA.DAS.AODP.Data.Tests/Repositories/Rollover/RolloverRepositoryTests.cs
@@ -1,5 +1,6 @@
 ﻿using AutoFixture;
 using AutoFixture.AutoMoq;
+using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using SFA.DAS.AODP.Data.Context;
 using SFA.DAS.AODP.Data.Entities.Offer;
@@ -22,12 +23,17 @@ public class RolloverRepositoryTests
 
     private static ApplicationDbContext CreateDb(string name)
     {
+        var connection = new SqliteConnection("DataSource=:memory:");
+        connection.Open();
         var options = new DbContextOptionsBuilder<ApplicationDbContext>()
-            .UseInMemoryDatabase($"{name}_{Guid.NewGuid()}")
-            .EnableSensitiveDataLogging()
+            .UseSqlite(connection)
             .Options;
 
-        return new ApplicationDbContext(options);
+        var context = new ApplicationDbContext(options);
+        context.Database.EnsureCreated();
+        context.Database.ExecuteSqlRaw("PRAGMA foreign_keys = OFF;");
+
+        return context;
     }
 
 

--- a/src/SFA.DAS.AODP.Data.Tests/Repositories/Rollover/RolloverRepositoryTests.cs
+++ b/src/SFA.DAS.AODP.Data.Tests/Repositories/Rollover/RolloverRepositoryTests.cs
@@ -109,12 +109,16 @@ public class RolloverRepositoryTests
             .Options;
 
         var now = DateTime.UtcNow;
-        var e1 = RolloverWorkflowCandidate.Create(Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid(), "2024/25", 1, now.AddDays(-3), null, now.AddDays(-3));
-        var e2 = RolloverWorkflowCandidate.Create(Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid(), "2024/25", 1, now.AddDays(-2), null, now.AddDays(-2));
-        var e3 = RolloverWorkflowCandidate.Create(Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid(), "2024/25", 1, now.AddDays(-1), null, now.AddDays(-1));
+        var workflowRun =
+            RolloverWorkflowRun.Create("2024/25", SelectionMethod.FileUpload, null, null, null, "system", now);
+
+        var e1 = RolloverWorkflowCandidate.Create(workflowRun.Id, Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid(), "2024/25", 1, now.AddDays(-3), null, now.AddDays(-3));
+        var e2 = RolloverWorkflowCandidate.Create(workflowRun.Id, Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid(), "2024/25", 1, now.AddDays(-2), null, now.AddDays(-2));
+        var e3 = RolloverWorkflowCandidate.Create(workflowRun.Id, Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid(), "2024/25", 1, now.AddDays(-1), null, now.AddDays(-1));
 
         await using (var db = new ApplicationDbContext(options))
         {
+            await db.RolloverWorkflowRuns.AddAsync(workflowRun, TestContext.Current.CancellationToken);
             await db.RolloverWorkflowCandidates.AddRangeAsync(new[] { e1, e2, e3 });
             await db.SaveChangesAsync(TestContext.Current.CancellationToken);
         }

--- a/src/SFA.DAS.AODP.Data.Tests/Repositories/Rollover/RolloverRepositoryTests.cs
+++ b/src/SFA.DAS.AODP.Data.Tests/Repositories/Rollover/RolloverRepositoryTests.cs
@@ -136,107 +136,6 @@ public class RolloverRepositoryTests
     }
 
     [Fact]
-    public async Task GetRolloverWorkflowCandidatesP1ChecksAsync_ReturnsEmpty_When_NoRecords()
-    {
-        // Arrange
-        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
-            .UseInMemoryDatabase("RolloverP1_NoRecords_" + Guid.NewGuid())
-            .Options;
-
-        await using var db = new ApplicationDbContext(options);
-        var sut = new RolloverRepository(db);
-
-        // Act
-        var result = (await sut.GetRolloverWorkflowCandidatesP1ChecksAsync(TestContext.Current.CancellationToken)).ToList();
-
-        // Assert
-        Assert.NotNull(result);
-        Assert.Empty(result);
-    }
-
-    [Fact]
-    public async Task GetRolloverWorkflowCandidatesP1ChecksAsync_ReturnsAllRecords()
-    {
-        // Arrange
-        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
-            .UseInMemoryDatabase("RolloverP1_AllRecords_" + Guid.NewGuid())
-            .Options;
-
-        var now = DateTime.UtcNow;
-        var e1 = new RolloverWorkflowCandidatesP1Checks
-        {
-            WorkflowCandidateId = Guid.NewGuid(),
-            QualificationVersionId = Guid.NewGuid(),
-            FundingOfferId = Guid.NewGuid(),
-            AcademicYear = "2025/26",
-            IncludedInP1Export = true,
-            IncludedInFinalUpload = false,
-            CurrentFundingEndDate = now.Date,
-            ProposedFundingEndDate = now.Date.AddYears(1),
-            FundingStream = "FS1",
-            RolloverRound = 1,
-            FundingEndDateThreshold = now.Date.AddDays(-10),
-            LatestFundingApprovalEndDate = now.Date.AddDays(-20),
-            OperationalStartDate = now.Date.AddYears(-1),
-            OperationalEndDate = now.Date.AddMonths(6),
-            OperationalEndDateThreshold = now.Date.AddDays(-5),
-            OfferedInEngland = true,
-            IsOnDefundingList = false
-        };
-
-        var e2 = new RolloverWorkflowCandidatesP1Checks
-        {
-            WorkflowCandidateId = Guid.NewGuid(),
-            QualificationVersionId = Guid.NewGuid(),
-            FundingOfferId = Guid.NewGuid(),
-            AcademicYear = "2026/27",
-            IncludedInP1Export = false,
-            IncludedInFinalUpload = true,
-            CurrentFundingEndDate = now.Date,
-            ProposedFundingEndDate = null,
-            FundingStream = null,
-            RolloverRound = 2,
-            FundingEndDateThreshold = now.Date.AddDays(30),
-            LatestFundingApprovalEndDate = now.Date.AddDays(60),
-            OperationalStartDate = now.Date,
-            OperationalEndDate = null,
-            OperationalEndDateThreshold = now.Date.AddDays(15),
-            OfferedInEngland = false,
-            IsOnDefundingList = true
-        };
-
-        await using (var db = new ApplicationDbContext(options))
-        {
-            await db.RolloverWorkflowCandidatesP1Checks.AddRangeAsync(new[] { e1, e2 });
-            await db.SaveChangesAsync(TestContext.Current.CancellationToken);
-        }
-
-        await using (var db = new ApplicationDbContext(options))
-        {
-            var sut = new RolloverRepository(db);
-
-            // Act
-            var result = (await sut.GetRolloverWorkflowCandidatesP1ChecksAsync(TestContext.Current.CancellationToken)).ToList();
-
-            // Assert
-            Assert.NotNull(result);
-            Assert.Equal(2, result.Count);
-            Assert.Contains(result, r => r.WorkflowCandidateId == e1.WorkflowCandidateId);
-            Assert.Contains(result, r => r.WorkflowCandidateId == e2.WorkflowCandidateId);
-
-            var fetched1 = result.Single(r => r.WorkflowCandidateId == e1.WorkflowCandidateId);
-            Assert.Equal(e1.AcademicYear, fetched1.AcademicYear);
-            Assert.Equal(e1.FundingStream, fetched1.FundingStream);
-            Assert.Equal(e1.IsOnDefundingList, fetched1.IsOnDefundingList);
-
-            var fetched2 = result.Single(r => r.WorkflowCandidateId == e2.WorkflowCandidateId);
-            Assert.Equal(e2.AcademicYear, fetched2.AcademicYear);
-            Assert.Equal(e2.FundingStream, fetched2.FundingStream);
-            Assert.Equal(e2.IsOnDefundingList, fetched2.IsOnDefundingList);
-        }
-    }
-
-    [Fact]
     public async Task GetRolloverWorkflowCandidatesByRunId_ReturnsEmpty_When_NoRecords()
     {
         // Arrange
@@ -521,78 +420,93 @@ public class RolloverRepositoryTests
     }
 
     [Fact]
-    public async Task CreateRolloverWorkflowRunAsync_AddsEntityAndReturnsId()
+    public async Task GetRolloverCandidatesWithP1ChecksAsync_WhenCandidateIsValid_ReturnsCandidateAndCheckData()
     {
         // Arrange
-        await using var db = CreateDb(nameof(CreateRolloverWorkflowRunAsync_AddsEntityAndReturnsId));
-        var sut = new RolloverRepository(db);
+        await using var db = CreateDb(
+            nameof(GetRolloverCandidatesWithP1ChecksAsync_WhenCandidateIsValid_ReturnsCandidateAndCheckData));
 
-        var workflowRun = RolloverWorkflowRun.Create(
-            "2024/25",
-            SFA.DAS.AODP.Data.Entities.Rollover.Enums.SelectionMethod.QueryBuilder,
-            DateTime.UtcNow.AddDays(-1),
-            DateTime.UtcNow.AddDays(-2),
-            DateTime.UtcNow.AddYears(1),
-            "test.user",
-            DateTime.UtcNow);
+        var qualification = new Qualification
+        {
+            Id = Guid.NewGuid(),
+            Qan = "P1000001"
+        };
+        var qualificationVersion = new QualificationVersions
+        {
+            Id = Guid.NewGuid(),
+            QualificationId = qualification.Id,
+            Qualification = qualification,
+            Status = "Live",
+            Type = "Certificate",
+            Ssa = "Science",
+            Level = "Level 3",
+            SubLevel = "3",
+            EqfLevel = "4",
+            OfferedInEngland = true,
+            IntentionToSeekFundingInEngland = true,
+            OperationalStartDate = new DateTime(2024, 8, 1),
+            OperationalEndDate = new DateTime(2027, 7, 31)
+        };
+        var fundingOffer = new FundingOffer
+        {
+            Id = Guid.NewGuid(),
+            Name = "AdultSkills",
+            DisplayName = "Adult skills"
+        };
+        var rolloverCandidate = RolloverCandidates.CreateInitialRound(
+            qualificationVersion.Id,
+            fundingOffer.Id,
+            "2025/26",
+            new DateTime(2025, 1, 1));
+        rolloverCandidate.QualificationVersion = qualificationVersion;
+        rolloverCandidate.FundingOffer = fundingOffer;
 
-        // Act
-        var id = await sut.CreateRolloverWorkflowRunAsync(workflowRun, TestContext.Current.CancellationToken);
+        var qualificationFunding = new QualificationFundings
+        {
+            Id = Guid.NewGuid(),
+            QualificationVersionId = qualificationVersion.Id,
+            FundingOfferId = fundingOffer.Id,
+            EndDate = new DateOnly(2026, 7, 31)
+        };
+        var pldns = new Data.Entities.Import.Pldns
+        {
+            Qan = qualification.Qan,
+            Pldns14To16 = new DateTime(2026, 6, 30),
+            ImportDate = new DateTime(2025, 1, 1)
+        };
 
-        // Assert
-        id.ShouldBe(workflowRun.Id);
-        var persisted = await db.RolloverWorkflowRuns.FirstOrDefaultAsync(r => r.Id == id, TestContext.Current.CancellationToken);
-        persisted.ShouldNotBeNull();
-        persisted!.AcademicYear.ShouldBe("2024/25");
-    }
-
-    [Fact]
-    public async Task CreateRolloverWorkflowCandidatesAsync_ReplacesExistingAndAddsIncoming()
-    {
-        // Arrange
-        await using var db = CreateDb(nameof(CreateRolloverWorkflowCandidatesAsync_ReplacesExistingAndAddsIncoming));
-
-        var candidateRecordId = Guid.NewGuid();
-
-        var existing = RolloverWorkflowCandidate.Create(Guid.NewGuid(), candidateRecordId, Guid.NewGuid(), Guid.NewGuid(), "2024/25", 1, DateTime.UtcNow, null, DateTime.UtcNow);
-        await db.RolloverWorkflowCandidates.AddAsync(existing, TestContext.Current.CancellationToken);
+        db.RolloverCandidates.Add(rolloverCandidate);
+        db.QualificationFundings.Add(qualificationFunding);
+        db.Pldns.Add(pldns);
         await db.SaveChangesAsync(TestContext.Current.CancellationToken);
 
-        var incoming1 = RolloverWorkflowCandidate.Create(Guid.NewGuid(), candidateRecordId, existing.QualificationVersionId, existing.FundingOfferId, "2024/25", 1, DateTime.UtcNow, null, DateTime.UtcNow);
-        var incoming2 = RolloverWorkflowCandidate.Create(Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid(), "2024/25", 1, DateTime.UtcNow, null, DateTime.UtcNow);
-
+        var fundingThreshold = new DateTime(2025, 7, 31);
+        var operationalThreshold = new DateTime(2025, 8, 1);
+        var maximumApprovalEndDate = new DateTime(2027, 7, 31);
         var sut = new RolloverRepository(db);
 
         // Act
-        await sut.CreateRolloverWorkflowCandidatesAsync(new[] { incoming1, incoming2 }, TestContext.Current.CancellationToken);
-
-        // Assert - existing should be removed and incoming present
-        var all = await db.RolloverWorkflowCandidates.ToListAsync(TestContext.Current.CancellationToken);
-        all.Count.ShouldBe(2);
-        all.ShouldContain(x => x.RolloverWorkflowRunId == incoming1.RolloverWorkflowRunId && x.RolloverCandidatesId == incoming1.RolloverCandidatesId);
-        all.ShouldContain(x => x.RolloverWorkflowRunId == incoming2.RolloverWorkflowRunId && x.RolloverCandidatesId == incoming2.RolloverCandidatesId);
-    }
-
-    [Fact]
-    public async Task CreateRolloverWorkflowRunFundingOffersAsync_AddsOffersAndSaves()
-    {
-        // Arrange
-        await using var db = CreateDb(nameof(CreateRolloverWorkflowRunFundingOffersAsync_AddsOffersAndSaves));
-
-        var runId = Guid.NewGuid();
-        var offer1 = RolloverWorkflowRunFundingOffer.Create(runId, Guid.NewGuid());
-        var offer2 = RolloverWorkflowRunFundingOffer.Create(runId, Guid.NewGuid());
-
-        var sut = new RolloverRepository(db);
-
-        // Act
-        await sut.CreateRolloverWorkflowRunFundingOffersAsync(new[] { offer1, offer2 }, TestContext.Current.CancellationToken);
+        var result = await sut.GetRolloverCandidatesWithP1ChecksAsync(
+            [new RolloverCandidateP1CheckRequest(
+                rolloverCandidate.Id,
+                fundingThreshold,
+                operationalThreshold,
+                maximumApprovalEndDate)],
+            TestContext.Current.CancellationToken);
 
         // Assert
-        var saved = await db.RolloverWorkflowRunFundingOffers.ToListAsync(TestContext.Current.CancellationToken);
-        saved.Count.ShouldBe(2);
-        saved.ShouldContain(x => x.RolloverWorkflowRunId == runId && x.FundingOfferId == offer1.FundingOfferId);
-        saved.ShouldContain(x => x.RolloverWorkflowRunId == runId && x.FundingOfferId == offer2.FundingOfferId);
+        var actual = result.ShouldHaveSingleItem();
+        actual.Candidate.Id.ShouldBe(rolloverCandidate.Id);
+        actual.Candidate.QualificationVersionId.ShouldBe(qualificationVersion.Id);
+        actual.Candidate.FundingOfferId.ShouldBe(fundingOffer.Id);
+        actual.P1Checks.RolloverCandidatesId.ShouldBe(rolloverCandidate.Id);
+        actual.P1Checks.FundingStream.ShouldBe(fundingOffer.Name);
+        actual.P1Checks.LatestFundingApprovalEndDate.ShouldBe(
+            new DateTime(2026, 7, 31));
+        actual.P1Checks.FundingEndDateThreshold.ShouldBe(fundingThreshold);
+        actual.P1Checks.OperationalEndDateThreshold.ShouldBe(operationalThreshold);
+        actual.P1Checks.MaximumApprovalEndDate.ShouldBe(maximumApprovalEndDate);
+        actual.P1Checks.Age1416.ShouldBe(pldns.Pldns14To16);
     }
 
     [Fact]

--- a/src/SFA.DAS.AODP.Data/Context/ApplicationDbContext.cs
+++ b/src/SFA.DAS.AODP.Data/Context/ApplicationDbContext.cs
@@ -93,6 +93,7 @@ namespace SFA.DAS.AODP.Data.Context
         public virtual DbSet<RolloverWorkflowRunFilterValue> RolloverWorkflowRunFilterValues { get; set; }
         public virtual DbSet<RolloverWorkflowCandidate> RolloverWorkflowCandidates { get; set; }
         public virtual DbSet<RolloverDecisionRun> RolloverDecisionRuns { get; set; }
+        public virtual DbSet<FundingExtensionStaging> FundingExtensionStaging { get; set; }
         public DbSet<RolloverWorkflowCandidatesP1Checks> RolloverWorkflowCandidatesP1Checks { get; set; }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)

--- a/src/SFA.DAS.AODP.Data/Context/IApplicationDbContext.cs
+++ b/src/SFA.DAS.AODP.Data/Context/IApplicationDbContext.cs
@@ -78,6 +78,7 @@ namespace SFA.DAS.AODP.Data.Context
         DbSet<RolloverWorkflowRunFilterValue> RolloverWorkflowRunFilterValues { get; set; }
         DbSet<RolloverWorkflowCandidate> RolloverWorkflowCandidates { get; set; }
         DbSet<RolloverDecisionRun> RolloverDecisionRuns { get; set; }
+        DbSet<FundingExtensionStaging> FundingExtensionStaging { get; set; }
 
         DbSet<RolloverWorkflowCandidatesP1Checks> RolloverWorkflowCandidatesP1Checks { get; set; }
 

--- a/src/SFA.DAS.AODP.Data/Entities/Rollover/FundingExtensionStaging.cs
+++ b/src/SFA.DAS.AODP.Data/Entities/Rollover/FundingExtensionStaging.cs
@@ -1,0 +1,18 @@
+using System.ComponentModel.DataAnnotations.Schema;
+using SFA.DAS.AODP.Models.Rollover;
+
+namespace SFA.DAS.AODP.Data.Entities.Rollover;
+
+[Table("FundingExtensionStaging")]
+public class FundingExtensionStaging
+{
+    public Guid OperationId { get; set; }
+    public Guid RolloverCandidateId { get; set; }
+    public Guid? QualificationFundingId { get; set; }
+    public RolloverStatus RolloverStatus { get; set; }
+    public string? ExclusionReason { get; set; }
+    public DateTime? NewFundingEndDate { get; set; }
+    public DateOnly? FundingEndDate { get; set; }
+    public string? FundingComments { get; set; }
+    public DateTime CreatedAt { get; set; }
+}

--- a/src/SFA.DAS.AODP.Data/Entities/Rollover/ModelBuilder/RolloverModelBuilderExtensions.cs
+++ b/src/SFA.DAS.AODP.Data/Entities/Rollover/ModelBuilder/RolloverModelBuilderExtensions.cs
@@ -27,6 +27,12 @@ public static class RolloverModelBuilderExtensions
                 .OnDelete(DeleteBehavior.SetNull);
         });
 
+        modelBuilder.Entity<FundingExtensionStaging>(b =>
+        {
+            b.HasKey(x => new { x.OperationId, x.RolloverCandidateId });
+            b.Property(x => x.RolloverStatus).HasConversion<string>();
+        });
+
         modelBuilder.Entity<RolloverWorkflowRun>(b =>
         {
             b.Property(x => x.SelectionMethod)

--- a/src/SFA.DAS.AODP.Data/Entities/Rollover/RolloverCandidateP1CheckData.cs
+++ b/src/SFA.DAS.AODP.Data/Entities/Rollover/RolloverCandidateP1CheckData.cs
@@ -1,0 +1,7 @@
+using SFA.DAS.AODP.Models.Rollover;
+
+namespace SFA.DAS.AODP.Data.Entities.Rollover;
+
+public record RolloverCandidateP1CheckData(
+    RolloverCandidateDto Candidate,
+    RolloverWorkflowCandidatesP1Checks P1Checks);

--- a/src/SFA.DAS.AODP.Data/Entities/Rollover/RolloverCandidateP1CheckRequest.cs
+++ b/src/SFA.DAS.AODP.Data/Entities/Rollover/RolloverCandidateP1CheckRequest.cs
@@ -1,0 +1,7 @@
+namespace SFA.DAS.AODP.Data.Entities.Rollover;
+
+public record RolloverCandidateP1CheckRequest(
+    Guid RolloverCandidateId,
+    DateTime? FundingEndDateEligibilityThreshold,
+    DateTime? OperationalEndDateEligibilityThreshold,
+    DateTime? MaximumApprovalFundingEndDate);

--- a/src/SFA.DAS.AODP.Data/Entities/Rollover/RolloverWorkflowCandidatesP1Checks.cs
+++ b/src/SFA.DAS.AODP.Data/Entities/Rollover/RolloverWorkflowCandidatesP1Checks.cs
@@ -3,6 +3,7 @@
 public class RolloverWorkflowCandidatesP1Checks
 {
     public Guid WorkflowCandidateId { get; set; }
+    public Guid RolloverCandidatesId { get; set; }
     public Guid QualificationVersionId { get; set; }
     public Guid FundingOfferId { get; set; }
     public string AcademicYear { get; set; } = string.Empty;

--- a/src/SFA.DAS.AODP.Data/Entities/Rollover/RolloverWorkflowRun.cs
+++ b/src/SFA.DAS.AODP.Data/Entities/Rollover/RolloverWorkflowRun.cs
@@ -52,6 +52,7 @@ public class RolloverWorkflowRun
 
         return new RolloverWorkflowRun
         {
+            Id = Guid.NewGuid(),
             AcademicYear = academicYear,
             SelectionMethod = selectionMethod,
             FundingEndDateEligibilityThreshold = fundingEndDateEligibilityThreshold,

--- a/src/SFA.DAS.AODP.Data/Extensions/DataExtensions.cs
+++ b/src/SFA.DAS.AODP.Data/Extensions/DataExtensions.cs
@@ -12,6 +12,7 @@ using SFA.DAS.AODP.Data.Repositories.Rollover;
 using System.Diagnostics.CodeAnalysis;
 using SFA.DAS.AODP.Data.Repositories.QaaQualification;
 using Microsoft.Extensions.Logging;
+using SFA.DAS.AODP.Data.Repositories.FundingExtension;
 
 namespace SFA.DAS.AODP.Data.Extensions
 {
@@ -20,7 +21,7 @@ namespace SFA.DAS.AODP.Data.Extensions
     {
         public static IServiceCollection ConfigureDatabase(this IServiceCollection services, IConfigurationRoot configuration)
         {
-            services.AddDbContext<IApplicationDbContext, ApplicationDbContext>(options =>
+            services.AddDbContext<ApplicationDbContext>(options =>
             {
                var  connectionString = configuration["AodpApi:DatabaseConnectionString"];
 
@@ -34,6 +35,8 @@ namespace SFA.DAS.AODP.Data.Extensions
                 }
                 options.UseSqlServer(connectionString);
             });
+            services.AddScoped<IApplicationDbContext>(provider =>
+                provider.GetRequiredService<ApplicationDbContext>());
             services.AddScoped<IFormVersionRepository, FormVersionRepository>();
             services.AddScoped<ISectionRepository, SectionRepository>();
             services.AddScoped<IPageRepository, PageRepository>();
@@ -67,6 +70,7 @@ namespace SFA.DAS.AODP.Data.Extensions
             services.AddScoped<IJobRunsRepository, JobRunsRepository>();
 
             services.AddScoped<IRolloverRepository, RolloverRepository>();
+            services.AddScoped<IFundingExtensionPersistenceRepository, FundingExtensionPersistenceRepository>();
 
             services.AddScoped<IQualificationOutputFileRepository, QualificationOutputFileRepository>();
             services.AddScoped<IQualificationOutputFileLogRepository, QualificationOutputFileLogRepository>();

--- a/src/SFA.DAS.AODP.Data/Repositories/FundingExtension/FundingExtensionPersistenceRepository.cs
+++ b/src/SFA.DAS.AODP.Data/Repositories/FundingExtension/FundingExtensionPersistenceRepository.cs
@@ -44,8 +44,7 @@ public class FundingExtensionPersistenceRepository(
                         nameof(RolloverCandidates.RolloverStatus),
                         nameof(RolloverCandidates.ExclusionReason),
                         nameof(RolloverCandidates.NewFundingEndDate)
-                    ],
-                    UseTempDB = true
+                    ]
                 };
 
                 await context.BulkUpdateAsync(
@@ -71,8 +70,7 @@ public class FundingExtensionPersistenceRepository(
                     [
                         nameof(QualificationFundings.EndDate),
                         nameof(QualificationFundings.Comments)
-                    ],
-                    UseTempDB = true
+                    ]
                 };
 
                 await context.BulkUpdateAsync(
@@ -93,7 +91,7 @@ public class FundingExtensionPersistenceRepository(
                 var historyInsertStarted = Stopwatch.GetTimestamp();
                 await context.BulkInsertAsync(
                     histories.ToList(),
-                    new BulkConfig { BatchSize = BatchSize, UseTempDB = true },
+                    new BulkConfig { BatchSize = BatchSize},
                     cancellationToken: cancellationToken);
                 
                 logger.LogInformation(

--- a/src/SFA.DAS.AODP.Data/Repositories/FundingExtension/FundingExtensionPersistenceRepository.cs
+++ b/src/SFA.DAS.AODP.Data/Repositories/FundingExtension/FundingExtensionPersistenceRepository.cs
@@ -1,0 +1,125 @@
+using EFCore.BulkExtensions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using System.Diagnostics;
+using SFA.DAS.AODP.Data.Context;
+using SFA.DAS.AODP.Data.Entities.Qualification;
+using SFA.DAS.AODP.Data.Entities.Rollover;
+
+namespace SFA.DAS.AODP.Data.Repositories.FundingExtension;
+
+public class FundingExtensionPersistenceRepository(
+    ApplicationDbContext context,
+    ILogger<FundingExtensionPersistenceRepository> logger)
+    : IFundingExtensionPersistenceRepository
+{
+    private const int BatchSize = 2_000;
+
+    public async Task PersistAsync(
+        IReadOnlyCollection<RolloverCandidates> candidates,
+        IReadOnlyCollection<QualificationFundings> fundings,
+        IReadOnlyCollection<QualificationDiscussionHistory> histories,
+        CancellationToken cancellationToken)
+    {
+        var totalStarted = Stopwatch.GetTimestamp();
+        var transactionStarted = Stopwatch.GetTimestamp();
+        await using var transaction = await context.Database.BeginTransactionAsync(cancellationToken);
+        logger.LogInformation(
+            "Started funding-extension persistence transaction in {ElapsedMilliseconds} ms",
+            Stopwatch.GetElapsedTime(transactionStarted).TotalMilliseconds);
+        var currentStage = "CandidateBulkUpdate";
+
+        try
+        {
+            if (candidates.Count > 0)
+            {
+                var candidateUpdateStarted = Stopwatch.GetTimestamp();
+                var candidateConfig = new BulkConfig
+                {
+                    BatchSize = BatchSize,
+                    PropertiesToInclude =
+                    [
+                        nameof(RolloverCandidates.RolloverStatus),
+                        nameof(RolloverCandidates.ExclusionReason),
+                        nameof(RolloverCandidates.NewFundingEndDate)
+                    ]
+                };
+
+                await context.BulkUpdateAsync(
+                    candidates.ToList(),
+                    candidateConfig,
+                    cancellationToken: cancellationToken);
+                logger.LogInformation(
+                    "Bulk updated {CandidateCount} rollover candidates in {ElapsedMilliseconds} ms using batch size {BatchSize}",
+                    candidates.Count,
+                    Stopwatch.GetElapsedTime(candidateUpdateStarted).TotalMilliseconds,
+                    BatchSize);
+            }
+
+            currentStage = "FundingBulkUpdate";
+            if (fundings.Count > 0)
+            {
+                var fundingUpdateStarted = Stopwatch.GetTimestamp();
+                var fundingConfig = new BulkConfig
+                {
+                    BatchSize = BatchSize,
+                    PropertiesToInclude =
+                    [
+                        nameof(QualificationFundings.EndDate),
+                        nameof(QualificationFundings.Comments)
+                    ]
+                };
+
+                await context.BulkUpdateAsync(
+                    fundings.ToList(),
+                    fundingConfig,
+                    cancellationToken: cancellationToken);
+                logger.LogInformation(
+                    "Bulk updated {FundingCount} qualification fundings in {ElapsedMilliseconds} ms using batch size {BatchSize}",
+                    fundings.Count,
+                    Stopwatch.GetElapsedTime(fundingUpdateStarted).TotalMilliseconds,
+                    BatchSize);
+            }
+
+            currentStage = "HistoryBulkInsert";
+            if (histories.Count > 0)
+            {
+                var historyInsertStarted = Stopwatch.GetTimestamp();
+                await context.BulkInsertAsync(
+                    histories.ToList(),
+                    new BulkConfig { BatchSize = BatchSize },
+                    cancellationToken: cancellationToken);
+                logger.LogInformation(
+                    "Bulk inserted {HistoryCount} discussion-history records in {ElapsedMilliseconds} ms using batch size {BatchSize}",
+                    histories.Count,
+                    Stopwatch.GetElapsedTime(historyInsertStarted).TotalMilliseconds,
+                    BatchSize);
+            }
+
+            currentStage = "WorkflowCandidateDelete";
+            var workflowDeleteStarted = Stopwatch.GetTimestamp();
+            await context.RolloverWorkflowCandidates.ExecuteDeleteAsync(cancellationToken);
+            logger.LogInformation(
+                "Deleted rollover workflow candidates in {ElapsedMilliseconds} ms",
+                Stopwatch.GetElapsedTime(workflowDeleteStarted).TotalMilliseconds);
+
+            currentStage = "TransactionCommit";
+            var commitStarted = Stopwatch.GetTimestamp();
+            await transaction.CommitAsync(cancellationToken);
+            logger.LogInformation(
+                "Committed funding-extension persistence transaction in {ElapsedMilliseconds} ms; total persistence time was {TotalElapsedMilliseconds} ms",
+                Stopwatch.GetElapsedTime(commitStarted).TotalMilliseconds,
+                Stopwatch.GetElapsedTime(totalStarted).TotalMilliseconds);
+        }
+        catch (Exception exception)
+        {
+            logger.LogError(
+                exception,
+                "Funding-extension persistence failed during {PersistenceStage} after {ElapsedMilliseconds} ms",
+                currentStage,
+                Stopwatch.GetElapsedTime(totalStarted).TotalMilliseconds);
+            await transaction.RollbackAsync(cancellationToken);
+            throw;
+        }
+    }
+}

--- a/src/SFA.DAS.AODP.Data/Repositories/FundingExtension/FundingExtensionPersistenceRepository.cs
+++ b/src/SFA.DAS.AODP.Data/Repositories/FundingExtension/FundingExtensionPersistenceRepository.cs
@@ -21,101 +21,141 @@ public class FundingExtensionPersistenceRepository(
         IReadOnlyCollection<QualificationDiscussionHistory> histories,
         CancellationToken cancellationToken)
     {
+        var operationId = Guid.NewGuid();
         var totalStarted = Stopwatch.GetTimestamp();
-        var transactionStarted = Stopwatch.GetTimestamp();
-        await using var transaction = await context.Database.BeginTransactionAsync(cancellationToken);
+        var currentStage = "StartTransaction";
 
-        logger.LogInformation(
-            "Started funding-extension persistence transaction in {ElapsedMilliseconds} ms",
-            Stopwatch.GetElapsedTime(transactionStarted).TotalMilliseconds);
-        
-        var currentStage = "CandidateBulkUpdate";
+        using var logScope = logger.BeginScope(
+            new Dictionary<string, object> { ["FundingExtensionOperationId"] = operationId });
+
+        await using var transaction = await context.Database.BeginTransactionAsync(cancellationToken);
 
         try
         {
-            if (candidates.Count > 0)
-            {
-                var candidateUpdateStarted = Stopwatch.GetTimestamp();
-                var candidateConfig = new BulkConfig
-                {
-                    BatchSize = BatchSize,
-                    PropertiesToInclude =
-                    [
-                        nameof(RolloverCandidates.RolloverStatus),
-                        nameof(RolloverCandidates.ExclusionReason),
-                        nameof(RolloverCandidates.NewFundingEndDate)
-                    ]
-                };
+            var createdAt = DateTime.UtcNow;
+            var stagingRows = CreateStagingRows(
+                operationId,
+                candidates,
+                fundings,
+                createdAt);
 
-                await context.BulkUpdateAsync(
-                    candidates.ToList(),
-                    candidateConfig,
+            currentStage = "StageChanges";
+            var stagingStarted = Stopwatch.GetTimestamp();
+            if (stagingRows.Count > 0)
+            {
+                await context.BulkInsertAsync(
+                    stagingRows,
+                    new BulkConfig
+                    {
+                        BatchSize = BatchSize,
+                        SetOutputIdentity = false
+                    },
                     cancellationToken: cancellationToken);
-                
-                logger.LogInformation(
-                    "Bulk updated {CandidateCount} rollover candidates in {ElapsedMilliseconds} ms using batch size {BatchSize}",
-                    candidates.Count,
-                    Stopwatch.GetElapsedTime(candidateUpdateStarted).TotalMilliseconds,
-                    BatchSize);
             }
 
-            currentStage = "FundingBulkUpdate";
-            if (fundings.Count > 0)
-            {
-                var fundingUpdateStarted = Stopwatch.GetTimestamp();
-                var fundingConfig = new BulkConfig
-                {
-                    BatchSize = BatchSize,
-                    PropertiesToInclude =
-                    [
-                        nameof(QualificationFundings.EndDate),
-                        nameof(QualificationFundings.Comments)
-                    ]
-                };
+            logger.LogInformation(
+                "Staged {StagingRowCount} funding-extension rows in {ElapsedMilliseconds} ms",
+                stagingRows.Count,
+                Stopwatch.GetElapsedTime(stagingStarted).TotalMilliseconds);
 
-                await context.BulkUpdateAsync(
-                    fundings.ToList(),
-                    fundingConfig,
-                    cancellationToken: cancellationToken);
-                
-                logger.LogInformation(
-                    "Bulk updated {FundingCount} qualification fundings in {ElapsedMilliseconds} ms using batch size {BatchSize}",
-                    fundings.Count,
-                    Stopwatch.GetElapsedTime(fundingUpdateStarted).TotalMilliseconds,
-                    BatchSize);
-            }
+            var operationRows = context.FundingExtensionStaging
+                .Where(row => row.OperationId == operationId);
 
-            currentStage = "HistoryBulkInsert";
+            currentStage = "ApplyCandidateUpdates";
+            var candidateUpdateStarted = Stopwatch.GetTimestamp();
+            var updatedCandidateCount = await context.RolloverCandidates
+                .Where(candidate => operationRows.Any(
+                    row => row.RolloverCandidateId == candidate.Id))
+                .ExecuteUpdateAsync(setters => setters
+                    .SetProperty(
+                        candidate => candidate.RolloverStatus,
+                        candidate => operationRows
+                            .Where(row => row.RolloverCandidateId == candidate.Id)
+                            .Select(row => row.RolloverStatus)
+                            .First())
+                    .SetProperty(
+                        candidate => candidate.ExclusionReason,
+                        candidate => operationRows
+                            .Where(row => row.RolloverCandidateId == candidate.Id)
+                            .Select(row => row.ExclusionReason)
+                            .First())
+                    .SetProperty(
+                        candidate => candidate.NewFundingEndDate,
+                        candidate => operationRows
+                            .Where(row => row.RolloverCandidateId == candidate.Id)
+                            .Select(row => row.NewFundingEndDate)
+                            .First()),
+                    cancellationToken);
+
+            EnsureExpectedRowCount("rollover candidate", candidates.Count, updatedCandidateCount);
+
+            logger.LogInformation(
+                "Updated {CandidateCount} rollover candidates in {ElapsedMilliseconds} ms",
+                updatedCandidateCount,
+                Stopwatch.GetElapsedTime(candidateUpdateStarted).TotalMilliseconds);
+
+            currentStage = "ApplyFundingUpdates";
+            var fundingUpdateStarted = Stopwatch.GetTimestamp();
+            var updatedFundingCount = await context.QualificationFundings
+                .Where(funding => operationRows.Any(
+                    row => row.QualificationFundingId == funding.Id))
+                .ExecuteUpdateAsync(setters => setters
+                    .SetProperty(
+                        funding => funding.EndDate,
+                        funding => operationRows
+                            .Where(row => row.QualificationFundingId == funding.Id)
+                            .Select(row => row.FundingEndDate)
+                            .First())
+                    .SetProperty(
+                        funding => funding.Comments,
+                        funding => operationRows
+                            .Where(row => row.QualificationFundingId == funding.Id)
+                            .Select(row => row.FundingComments)
+                            .First()),
+                    cancellationToken);
+
+            EnsureExpectedRowCount("qualification funding", fundings.Count, updatedFundingCount);
+
+            logger.LogInformation(
+                "Updated {FundingCount} qualification fundings in {ElapsedMilliseconds} ms",
+                updatedFundingCount,
+                Stopwatch.GetElapsedTime(fundingUpdateStarted).TotalMilliseconds);
+
+            currentStage = "InsertHistory";
+            var historyStarted = Stopwatch.GetTimestamp();
             if (histories.Count > 0)
             {
-                var historyInsertStarted = Stopwatch.GetTimestamp();
                 await context.BulkInsertAsync(
                     histories.ToList(),
-                    new BulkConfig { BatchSize = BatchSize},
+                    new BulkConfig
+                    {
+                        BatchSize = BatchSize,
+                        SetOutputIdentity = false
+                    },
                     cancellationToken: cancellationToken);
-                
-                logger.LogInformation(
-                    "Bulk inserted {HistoryCount} discussion-history records in {ElapsedMilliseconds} ms using batch size {BatchSize}",
-                    histories.Count,
-                    Stopwatch.GetElapsedTime(historyInsertStarted).TotalMilliseconds,
-                    BatchSize);
             }
 
-            currentStage = "WorkflowCandidateDelete";
-            var workflowDeleteStarted = Stopwatch.GetTimestamp();
-            await context.RolloverWorkflowCandidates.ExecuteDeleteAsync(cancellationToken);
-            
             logger.LogInformation(
-                "Deleted rollover workflow candidates in {ElapsedMilliseconds} ms",
-                Stopwatch.GetElapsedTime(workflowDeleteStarted).TotalMilliseconds);
+                "Inserted {HistoryCount} discussion-history rows in {ElapsedMilliseconds} ms",
+                histories.Count,
+                Stopwatch.GetElapsedTime(historyStarted).TotalMilliseconds);
 
-            currentStage = "TransactionCommit";
-            var commitStarted = Stopwatch.GetTimestamp();
+            currentStage = "CompleteWorkflow";
+            await context.RolloverWorkflowCandidates.ExecuteDeleteAsync(cancellationToken);
+
+            currentStage = "ClearStaging";
+            var clearedStagingCount = await context.FundingExtensionStaging
+                .Where(row => row.OperationId == operationId)
+                .ExecuteDeleteAsync(cancellationToken);
+            EnsureExpectedRowCount("funding-extension staging", stagingRows.Count, clearedStagingCount);
+
+            currentStage = "CommitTransaction";
             await transaction.CommitAsync(cancellationToken);
-            
+
             logger.LogInformation(
-                "Committed funding-extension persistence transaction in {ElapsedMilliseconds} ms; total persistence time was {TotalElapsedMilliseconds} ms",
-                Stopwatch.GetElapsedTime(commitStarted).TotalMilliseconds,
+                "Completed funding-extension persistence for {CandidateCount} candidates and cleared {StagingRowCount} staging rows in {ElapsedMilliseconds} ms",
+                candidates.Count,
+                stagingRows.Count,
                 Stopwatch.GetElapsedTime(totalStarted).TotalMilliseconds);
         }
         catch (Exception exception)
@@ -125,9 +165,91 @@ public class FundingExtensionPersistenceRepository(
                 "Funding-extension persistence failed during {PersistenceStage} after {ElapsedMilliseconds} ms",
                 currentStage,
                 Stopwatch.GetElapsedTime(totalStarted).TotalMilliseconds);
-            
-            await transaction.RollbackAsync(cancellationToken);
+
+            await RollbackAndCleanupAsync(transaction, operationId);
             throw;
+        }
+        finally
+        {
+            context.ChangeTracker.Clear();
+        }
+    }
+
+    private static List<FundingExtensionStaging> CreateStagingRows(
+        Guid operationId,
+        IReadOnlyCollection<RolloverCandidates> candidates,
+        IReadOnlyCollection<QualificationFundings> fundings,
+        DateTime createdAt)
+    {
+        var fundingLookup = fundings.ToDictionary(
+            funding => (funding.QualificationVersionId, funding.FundingOfferId));
+
+        return candidates.Select(candidate =>
+        {
+            fundingLookup.TryGetValue(
+                (candidate.QualificationVersionId, candidate.FundingOfferId),
+                out var funding);
+
+            return new FundingExtensionStaging
+            {
+                OperationId = operationId,
+                RolloverCandidateId = candidate.Id,
+                QualificationFundingId = funding?.Id,
+                RolloverStatus = candidate.RolloverStatus,
+                ExclusionReason = candidate.ExclusionReason,
+                NewFundingEndDate = candidate.NewFundingEndDate,
+                FundingEndDate = funding?.EndDate,
+                FundingComments = funding?.Comments,
+                CreatedAt = createdAt
+            };
+        }).ToList();
+    }
+
+    private static void EnsureExpectedRowCount(
+        string rowType,
+        int expectedCount,
+        int actualCount)
+    {
+        if (expectedCount != actualCount)
+        {
+            throw new DbUpdateConcurrencyException(
+                $"Expected to affect {expectedCount} {rowType} rows but affected {actualCount}.");
+        }
+    }
+
+    private async Task RollbackAndCleanupAsync(
+        Microsoft.EntityFrameworkCore.Storage.IDbContextTransaction transaction,
+        Guid operationId)
+    {
+        try
+        {
+            await transaction.RollbackAsync(CancellationToken.None);
+        }
+        catch (Exception rollbackException)
+        {
+            logger.LogError(
+                rollbackException,
+                "Failed to roll back funding-extension transaction");
+        }
+
+        try
+        {
+            var cleanedStagingCount = await context.FundingExtensionStaging
+                .Where(row => row.OperationId == operationId)
+                .ExecuteDeleteAsync(CancellationToken.None);
+
+            if (cleanedStagingCount > 0)
+            {
+                logger.LogWarning(
+                    "Removed {StagingRowCount} funding-extension staging rows after failure",
+                    cleanedStagingCount);
+            }
+        }
+        catch (Exception cleanupException)
+        {
+            logger.LogError(
+                cleanupException,
+                "Failed to clean funding-extension staging rows after rollback");
         }
     }
 }

--- a/src/SFA.DAS.AODP.Data/Repositories/FundingExtension/FundingExtensionPersistenceRepository.cs
+++ b/src/SFA.DAS.AODP.Data/Repositories/FundingExtension/FundingExtensionPersistenceRepository.cs
@@ -44,7 +44,8 @@ public class FundingExtensionPersistenceRepository(
                         nameof(RolloverCandidates.RolloverStatus),
                         nameof(RolloverCandidates.ExclusionReason),
                         nameof(RolloverCandidates.NewFundingEndDate)
-                    ]
+                    ],
+                    UseTempDB = true
                 };
 
                 await context.BulkUpdateAsync(
@@ -70,7 +71,8 @@ public class FundingExtensionPersistenceRepository(
                     [
                         nameof(QualificationFundings.EndDate),
                         nameof(QualificationFundings.Comments)
-                    ]
+                    ],
+                    UseTempDB = true
                 };
 
                 await context.BulkUpdateAsync(
@@ -91,7 +93,7 @@ public class FundingExtensionPersistenceRepository(
                 var historyInsertStarted = Stopwatch.GetTimestamp();
                 await context.BulkInsertAsync(
                     histories.ToList(),
-                    new BulkConfig { BatchSize = BatchSize },
+                    new BulkConfig { BatchSize = BatchSize, UseTempDB = true },
                     cancellationToken: cancellationToken);
                 
                 logger.LogInformation(

--- a/src/SFA.DAS.AODP.Data/Repositories/FundingExtension/FundingExtensionPersistenceRepository.cs
+++ b/src/SFA.DAS.AODP.Data/Repositories/FundingExtension/FundingExtensionPersistenceRepository.cs
@@ -24,9 +24,11 @@ public class FundingExtensionPersistenceRepository(
         var totalStarted = Stopwatch.GetTimestamp();
         var transactionStarted = Stopwatch.GetTimestamp();
         await using var transaction = await context.Database.BeginTransactionAsync(cancellationToken);
+
         logger.LogInformation(
             "Started funding-extension persistence transaction in {ElapsedMilliseconds} ms",
             Stopwatch.GetElapsedTime(transactionStarted).TotalMilliseconds);
+        
         var currentStage = "CandidateBulkUpdate";
 
         try
@@ -49,6 +51,7 @@ public class FundingExtensionPersistenceRepository(
                     candidates.ToList(),
                     candidateConfig,
                     cancellationToken: cancellationToken);
+                
                 logger.LogInformation(
                     "Bulk updated {CandidateCount} rollover candidates in {ElapsedMilliseconds} ms using batch size {BatchSize}",
                     candidates.Count,
@@ -74,6 +77,7 @@ public class FundingExtensionPersistenceRepository(
                     fundings.ToList(),
                     fundingConfig,
                     cancellationToken: cancellationToken);
+                
                 logger.LogInformation(
                     "Bulk updated {FundingCount} qualification fundings in {ElapsedMilliseconds} ms using batch size {BatchSize}",
                     fundings.Count,
@@ -89,6 +93,7 @@ public class FundingExtensionPersistenceRepository(
                     histories.ToList(),
                     new BulkConfig { BatchSize = BatchSize },
                     cancellationToken: cancellationToken);
+                
                 logger.LogInformation(
                     "Bulk inserted {HistoryCount} discussion-history records in {ElapsedMilliseconds} ms using batch size {BatchSize}",
                     histories.Count,
@@ -99,6 +104,7 @@ public class FundingExtensionPersistenceRepository(
             currentStage = "WorkflowCandidateDelete";
             var workflowDeleteStarted = Stopwatch.GetTimestamp();
             await context.RolloverWorkflowCandidates.ExecuteDeleteAsync(cancellationToken);
+            
             logger.LogInformation(
                 "Deleted rollover workflow candidates in {ElapsedMilliseconds} ms",
                 Stopwatch.GetElapsedTime(workflowDeleteStarted).TotalMilliseconds);
@@ -106,6 +112,7 @@ public class FundingExtensionPersistenceRepository(
             currentStage = "TransactionCommit";
             var commitStarted = Stopwatch.GetTimestamp();
             await transaction.CommitAsync(cancellationToken);
+            
             logger.LogInformation(
                 "Committed funding-extension persistence transaction in {ElapsedMilliseconds} ms; total persistence time was {TotalElapsedMilliseconds} ms",
                 Stopwatch.GetElapsedTime(commitStarted).TotalMilliseconds,
@@ -118,6 +125,7 @@ public class FundingExtensionPersistenceRepository(
                 "Funding-extension persistence failed during {PersistenceStage} after {ElapsedMilliseconds} ms",
                 currentStage,
                 Stopwatch.GetElapsedTime(totalStarted).TotalMilliseconds);
+            
             await transaction.RollbackAsync(cancellationToken);
             throw;
         }

--- a/src/SFA.DAS.AODP.Data/Repositories/FundingExtension/IFundingExtensionPersistenceRepository.cs
+++ b/src/SFA.DAS.AODP.Data/Repositories/FundingExtension/IFundingExtensionPersistenceRepository.cs
@@ -1,0 +1,13 @@
+using SFA.DAS.AODP.Data.Entities.Qualification;
+using SFA.DAS.AODP.Data.Entities.Rollover;
+
+namespace SFA.DAS.AODP.Data.Repositories.FundingExtension;
+
+public interface IFundingExtensionPersistenceRepository
+{
+    Task PersistAsync(
+        IReadOnlyCollection<RolloverCandidates> candidates,
+        IReadOnlyCollection<QualificationFundings> fundings,
+        IReadOnlyCollection<QualificationDiscussionHistory> histories,
+        CancellationToken cancellationToken);
+}

--- a/src/SFA.DAS.AODP.Data/Repositories/Qualification/QualificationFundingsRepository.cs
+++ b/src/SFA.DAS.AODP.Data/Repositories/Qualification/QualificationFundingsRepository.cs
@@ -52,13 +52,27 @@ namespace SFA.DAS.AODP.Data.Repositories.Qualification
             List<QualificationFundingKey> candidates,
             CancellationToken cancellationToken)
         {
+            if (candidates.Count == 0)
+            {
+                return [];
+            }
+
             var keySet = candidates
-                .Select(x => x.QualificationVersionId + "|" +  x.FundingOfferId )
+                .Select(x => (x.QualificationVersionId, x.FundingOfferId))
+                .ToHashSet();
+
+            var qualificationVersionIds = keySet
+                .Select(x => x.QualificationVersionId)
                 .ToList();
 
-            return await _context.QualificationFundings
-                .Where(qf => keySet.Contains(qf.QualificationVersionId + "|" + qf.FundingOfferId))
+            var possibleFundings = await _context.QualificationFundings
+                .AsNoTracking()
+                .Where(qf => qualificationVersionIds.Contains(qf.QualificationVersionId))
                 .ToListAsync(cancellationToken);
+
+            return possibleFundings
+                .Where(qf => keySet.Contains((qf.QualificationVersionId, qf.FundingOfferId)))
+                .ToList();
         }
     }
 }

--- a/src/SFA.DAS.AODP.Data/Repositories/Rollover/IRolloverRepository.cs
+++ b/src/SFA.DAS.AODP.Data/Repositories/Rollover/IRolloverRepository.cs
@@ -6,7 +6,6 @@ public interface IRolloverRepository
 {
     Task<int> GetRolloverWorkflowCandidatesCountAsync(CancellationToken cancellationToken);
     Task<IEnumerable<RolloverWorkflowCandidate>> GetAllRolloverWorkflowCandidatesAsync(CancellationToken cancellationToken);
-    Task<IEnumerable<RolloverWorkflowCandidatesP1Checks>> GetRolloverWorkflowCandidatesP1ChecksAsync(CancellationToken cancellationToken);
 
     Task UpdateRolloverWorkflowCandidatesAsync(IEnumerable<RolloverWorkflowCandidate> candidates, CancellationToken cancellationToken);
 
@@ -17,14 +16,15 @@ public interface IRolloverRepository
 
     Task<IEnumerable<RolloverCandidateDto>> GetRolloverCandidatesByIdsAsync(IReadOnlyCollection<Guid> rolloverCandidateIds, 
         CancellationToken cancellationToken);
+    Task<IReadOnlyList<RolloverCandidateP1CheckData>> GetRolloverCandidatesWithP1ChecksAsync(
+        IReadOnlyCollection<RolloverCandidateP1CheckRequest> requests,
+        CancellationToken cancellationToken);
     Task<RolloverWorkflowRun?> GeRolloverWorkflowRunByIdAsync(Guid id, CancellationToken cancellationToken);
 
-    Task<Guid> CreateRolloverWorkflowRunAsync(RolloverWorkflowRun request,
-        CancellationToken cancellationToken);
-
-    Task CreateRolloverWorkflowCandidatesAsync(IEnumerable<RolloverWorkflowCandidate> workflowCandidates,
-        CancellationToken cancellationToken);
-    Task CreateRolloverWorkflowRunFundingOffersAsync(IEnumerable<RolloverWorkflowRunFundingOffer> request,
+    Task<Guid> CreateRolloverWorkflowAsync(
+        RolloverWorkflowRun workflowRun,
+        IReadOnlyCollection<RolloverWorkflowCandidate> workflowCandidates,
+        IReadOnlyCollection<RolloverWorkflowRunFundingOffer> workflowFundingOffers,
         CancellationToken cancellationToken);
 
     Task SaveChangesAsync(CancellationToken cancellationToken);
@@ -58,6 +58,5 @@ public interface IRolloverRepository
     Task<IEnumerable<RolloverQueryBuilderAwardingOrganisation>> GetAwardingOrganisationsForRolloverQueryBuilderAsync(
         RolloverQueryBuilderAwardingOrganisationsRequest filters,
         CancellationToken cancellationToken);
-
     Task<RolloverStartSummary> GetRolloverStartSummaryAsync(string academicYear, CancellationToken cancellationToken);
 }

--- a/src/SFA.DAS.AODP.Data/Repositories/Rollover/RolloverRepository.cs
+++ b/src/SFA.DAS.AODP.Data/Repositories/Rollover/RolloverRepository.cs
@@ -21,15 +21,9 @@ public class RolloverRepository(IApplicationDbContext context) : IRolloverReposi
 
     public async Task<IEnumerable<RolloverWorkflowCandidate>> GetAllRolloverWorkflowCandidatesAsync(CancellationToken cancellationToken)
     {
-        return await context.RolloverWorkflowCandidates.ToListAsync(cancellationToken);
-    }
-
-    public async Task<IEnumerable<RolloverWorkflowCandidatesP1Checks>> GetRolloverWorkflowCandidatesP1ChecksAsync(CancellationToken cancellationToken)
-    {
-        var dbSet = context.RolloverWorkflowCandidatesP1Checks;
-        var query = await dbSet.AsNoTracking().ToListAsync(cancellationToken);
-
-        return query;
+        return await context.RolloverWorkflowCandidates
+            .Include(x => x.RolloverWorkflowRun)
+            .ToListAsync(cancellationToken);
     }
 
     public async Task UpdateRolloverWorkflowCandidatesAsync(IEnumerable<RolloverWorkflowCandidate> candidates, CancellationToken cancellationToken)
@@ -80,38 +74,148 @@ public class RolloverRepository(IApplicationDbContext context) : IRolloverReposi
             .ToListAsync(cancellationToken);
     }
 
-    public async Task<Guid> CreateRolloverWorkflowRunAsync(RolloverWorkflowRun workflowRun, CancellationToken cancellationToken = default)
-    {
-        context.RolloverWorkflowRuns.Add(workflowRun);
-        await context.SaveChangesAsync(cancellationToken);
-        return workflowRun.Id;
-    }
-
-    public async Task CreateRolloverWorkflowCandidatesAsync(
-        IEnumerable<RolloverWorkflowCandidate> workflowCandidates,
+    public async Task<IReadOnlyList<RolloverCandidateP1CheckData>> GetRolloverCandidatesWithP1ChecksAsync(
+        IReadOnlyCollection<RolloverCandidateP1CheckRequest> requests,
         CancellationToken cancellationToken)
     {
-        var incomingRolloverCandidates = workflowCandidates.ToList();
+        var rolloverCandidateIds = requests
+            .Select(x => x.RolloverCandidateId)
+            .ToList();
+        var requestsByCandidateId = requests.ToDictionary(x => x.RolloverCandidateId);
 
-        var incomingCandidateIds = incomingRolloverCandidates
+        var candidateData = await context.RolloverCandidates
+            .AsNoTracking()
+            .Where(rc => rolloverCandidateIds.Contains(rc.Id) && rc.IsActive)
+            .Select(rc => new
+            {
+                RolloverCandidatesId = rc.Id,
+                rc.QualificationVersionId,
+                rc.FundingOfferId,
+                FundingStream = rc.FundingOffer.Name,
+                rc.AcademicYear,
+                rc.RolloverRound,
+                rc.PreviousFundingEndDate,
+                rc.NewFundingEndDate,
+                rc.QualificationVersion.OperationalStartDate,
+                rc.QualificationVersion.OperationalEndDate,
+                rc.QualificationVersion.OfferedInEngland,
+                rc.QualificationVersion.IntentionToSeekFundingInEngland,
+                Qan = rc.QualificationVersion.Qualification.Qan,
+                HasFunding = context.QualificationFundings.Any(qf =>
+                    qf.QualificationVersionId == rc.QualificationVersionId &&
+                    qf.FundingOfferId == rc.FundingOfferId),
+                LatestFundingApprovalEndDate = context.QualificationFundings
+                    .Where(qf =>
+                        qf.QualificationVersionId == rc.QualificationVersionId &&
+                        qf.FundingOfferId == rc.FundingOfferId)
+                    .Max(qf => qf.EndDate)
+            })
+            .ToListAsync(cancellationToken);
+
+        var qans = candidateData
+            .Select(x => x.Qan)
+            .Distinct()
+            .ToList();
+
+        var defundedQans = await context.DefundingLists
+            .AsNoTracking()
+            .Where(x => qans.Contains(x.Qan))
+            .Select(x => x.Qan)
+            .ToHashSetAsync(cancellationToken);
+
+        var pldnsByQan = (await context.Pldns
+                .AsNoTracking()
+                .Where(x => qans.Contains(x.Qan))
+                .ToListAsync(cancellationToken))
+            .GroupBy(x => x.Qan)
+            .ToDictionary(
+                group => group.Key,
+                group => group.OrderByDescending(x => x.ImportDate).First());
+
+        return candidateData
+            .Select(candidate =>
+            {
+                pldnsByQan.TryGetValue(candidate.Qan, out var pldns);
+                var request = requestsByCandidateId[candidate.RolloverCandidatesId];
+
+                return new RolloverCandidateP1CheckData(
+                    new RolloverCandidateDto
+                    {
+                        Id = candidate.RolloverCandidatesId,
+                        QualificationVersionId = candidate.QualificationVersionId,
+                        FundingOfferId = candidate.FundingOfferId,
+                        AcademicYear = candidate.AcademicYear,
+                        RolloverRound = candidate.RolloverRound,
+                        PreviousFundingEndDate = candidate.PreviousFundingEndDate,
+                        NewFundingEndDate = candidate.NewFundingEndDate
+                    },
+                    new RolloverWorkflowCandidatesP1Checks
+                    {
+                        RolloverCandidatesId = candidate.RolloverCandidatesId,
+                        QualificationVersionId = candidate.QualificationVersionId,
+                        FundingOfferId = candidate.FundingOfferId,
+                        FundingStream = candidate.HasFunding ? candidate.FundingStream : null,
+                        AcademicYear = candidate.AcademicYear,
+                        RolloverRound = candidate.RolloverRound,
+                        FundingEndDateThreshold = request.FundingEndDateEligibilityThreshold,
+                        OperationalEndDateThreshold =
+                            request.OperationalEndDateEligibilityThreshold,
+                        MaximumApprovalEndDate = request.MaximumApprovalFundingEndDate,
+                        LatestFundingApprovalEndDate = candidate.LatestFundingApprovalEndDate?
+                            .ToDateTime(TimeOnly.MinValue),
+                        OperationalStartDate = candidate.OperationalStartDate,
+                        OperationalEndDate = candidate.OperationalEndDate,
+                        OfferedInEngland = candidate.OfferedInEngland,
+                        IntentionToSeekFundingInEngland =
+                            candidate.IntentionToSeekFundingInEngland ?? false,
+                        IsOnDefundingList = defundedQans.Contains(candidate.Qan),
+                        Age1416 = pldns?.Pldns14To16,
+                        Age1619 = pldns?.Pldns16To19,
+                        LocalFlexibilities = pldns?.LocalFlex,
+                        LegalEntitlementL2L3 = pldns?.LegalEntitlementL2L3,
+                        LegalEntitlementEnglishandMaths = pldns?.LegalEntitlementEngMaths,
+                        DigitalEntitlement = pldns?.DigitalEntitlement,
+                        ESFL3L4 = pldns?.EsfL3L4,
+                        AdvancedLearnerLoans = pldns?.Loans,
+                        LifelongLearningEntitlement = pldns?.LifelongLearning,
+                        L3FreeCoursesForJobs = pldns?.Level3FCoursesForJobs,
+                        CoF = pldns?.Cof
+                    });
+            })
+            .ToList();
+    }
+
+    public async Task<Guid> CreateRolloverWorkflowAsync(
+        RolloverWorkflowRun workflowRun,
+        IReadOnlyCollection<RolloverWorkflowCandidate> workflowCandidates,
+        IReadOnlyCollection<RolloverWorkflowRunFundingOffer> workflowFundingOffers,
+        CancellationToken cancellationToken)
+    {
+        var incomingCandidateIds = workflowCandidates
             .Select(x => x.RolloverCandidatesId)
             .ToList();
 
-        var existingWorkflowCandidates = await context.RolloverWorkflowCandidates
-            .Where(x => incomingCandidateIds.Contains(x.RolloverCandidatesId))
-            .ToListAsync(cancellationToken);
+        await using var transaction = await context.StartTransactionAsync();
+        try
+        {
+            await context.RolloverWorkflowCandidates
+                .Where(x => incomingCandidateIds.Contains(x.RolloverCandidatesId))
+                .ExecuteDeleteAsync(cancellationToken);
 
-        context.RolloverWorkflowCandidates.RemoveRange(existingWorkflowCandidates);
+            context.RolloverWorkflowRuns.Add(workflowRun);
+            context.RolloverWorkflowCandidates.AddRange(workflowCandidates);
+            context.RolloverWorkflowRunFundingOffers.AddRange(workflowFundingOffers);
 
-        context.RolloverWorkflowCandidates.AddRange(incomingRolloverCandidates);
+            await context.SaveChangesAsync(cancellationToken);
+            await transaction.CommitAsync(cancellationToken);
 
-        await context.SaveChangesAsync(cancellationToken);
-    }
-
-    public async Task CreateRolloverWorkflowRunFundingOffersAsync(IEnumerable<RolloverWorkflowRunFundingOffer> workflowFundingOffers, CancellationToken cancellationToken)
-    {
-        context.RolloverWorkflowRunFundingOffers.AddRange(workflowFundingOffers);
-        await context.SaveChangesAsync(cancellationToken);
+            return workflowRun.Id;
+        }
+        catch
+        {
+            await transaction.RollbackAsync(cancellationToken);
+            throw;
+        }
     }
 
     public Task SaveChangesAsync(CancellationToken cancellationToken)
@@ -390,7 +494,6 @@ public class RolloverRepository(IApplicationDbContext context) : IRolloverReposi
 
         return query;
     }
-
     public async Task<RolloverStartSummary> GetRolloverStartSummaryAsync(string academicYear, CancellationToken cancellationToken) 
     {
         var candidates = await context.RolloverCandidates

--- a/src/SFA.DAS.AODP.Data/Repositories/Rollover/RolloverRepository.cs
+++ b/src/SFA.DAS.AODP.Data/Repositories/Rollover/RolloverRepository.cs
@@ -203,8 +203,14 @@ public class RolloverRepository(IApplicationDbContext context) : IRolloverReposi
         try
         {
             // ExecuteDeleteAsync executes immediately! and does not use implicit transactions.
+            var allCandidates = await context.RolloverWorkflowCandidates.AsNoTracking().ToListAsync(cancellationToken);
+            var toDelete = allCandidates
+                .Where(o => !incomingCandidateIds.Contains(o.RolloverCandidatesId))
+                .Select(o => o.Id)
+                .ToHashSet();
+
             await context.RolloverWorkflowCandidates
-                .Where(x => !EF.Constant(incomingCandidateIds).Contains(x.RolloverCandidatesId))
+                .Where(x => EF.Constant(toDelete).Contains(x.RolloverCandidatesId))
                 .ExecuteDeleteAsync(cancellationToken);
 
             context.RolloverWorkflowRuns.Add(workflowRun);

--- a/src/SFA.DAS.AODP.Data/Repositories/Rollover/RolloverRepository.cs
+++ b/src/SFA.DAS.AODP.Data/Repositories/Rollover/RolloverRepository.cs
@@ -361,11 +361,7 @@ public class RolloverRepository(IApplicationDbContext context) : IRolloverReposi
 
     public async Task DeleteAllWorkflowCandidatesAsync(CancellationToken cancellationToken)
     {
-        var items = await context.RolloverWorkflowCandidates
-            .ToListAsync(cancellationToken);
-
-        context.RolloverWorkflowCandidates.RemoveRange(items);
-        await context.SaveChangesAsync(cancellationToken);
+        await context.RolloverWorkflowCandidates.ExecuteDeleteAsync(cancellationToken);
     }
 
     public async Task<Guid?> GetLatestWorkflowRunIdAsync(CancellationToken cancellationToken)

--- a/src/SFA.DAS.AODP.Data/Repositories/Rollover/RolloverRepository.cs
+++ b/src/SFA.DAS.AODP.Data/Repositories/Rollover/RolloverRepository.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.EntityFrameworkCore;
+﻿using System.Diagnostics;
+using Microsoft.EntityFrameworkCore;
 using SFA.DAS.AODP.Data.Context;
 using SFA.DAS.AODP.Data.Entities.Qualification;
 using SFA.DAS.AODP.Data.Entities.Rollover;
@@ -195,11 +196,15 @@ public class RolloverRepository(IApplicationDbContext context) : IRolloverReposi
             .Select(x => x.RolloverCandidatesId)
             .ToList();
 
+        // Explicit transaction as we are calling ExecuteDeleteAsync for better set based delete operations,
+        // this doesn't implicitly create transactions and runs immediately, therefore an explicit transaction is needed.
+        // This is so we can ensure a proper unit of work around the delete and the subsequent inserts such that if the delete fails then we roll back the entire thing.
         await using var transaction = await context.StartTransactionAsync();
         try
         {
+            // ExecuteDeleteAsync executes immediately! and does not use implicit transactions.
             await context.RolloverWorkflowCandidates
-                .Where(x => !incomingCandidateIds.Contains(x.RolloverCandidatesId))
+                .Where(x => !EF.Constant(incomingCandidateIds.Contains(x.RolloverCandidatesId)))
                 .ExecuteDeleteAsync(cancellationToken);
 
             context.RolloverWorkflowRuns.Add(workflowRun);

--- a/src/SFA.DAS.AODP.Data/Repositories/Rollover/RolloverRepository.cs
+++ b/src/SFA.DAS.AODP.Data/Repositories/Rollover/RolloverRepository.cs
@@ -203,14 +203,8 @@ public class RolloverRepository(IApplicationDbContext context) : IRolloverReposi
         try
         {
             // ExecuteDeleteAsync executes immediately! and does not use implicit transactions.
-            var allCandidates = await context.RolloverWorkflowCandidates.AsNoTracking().ToListAsync(cancellationToken);
-            var toDelete = allCandidates
-                .Where(o => !incomingCandidateIds.Contains(o.RolloverCandidatesId))
-                .Select(o => o.Id)
-                .ToHashSet();
-
             await context.RolloverWorkflowCandidates
-                .Where(x => EF.Constant(toDelete).Contains(x.RolloverCandidatesId))
+                .Where(x => EF.Constant(incomingCandidateIds).Contains(x.RolloverCandidatesId))
                 .ExecuteDeleteAsync(cancellationToken);
 
             context.RolloverWorkflowRuns.Add(workflowRun);

--- a/src/SFA.DAS.AODP.Data/Repositories/Rollover/RolloverRepository.cs
+++ b/src/SFA.DAS.AODP.Data/Repositories/Rollover/RolloverRepository.cs
@@ -204,7 +204,7 @@ public class RolloverRepository(IApplicationDbContext context) : IRolloverReposi
         {
             // ExecuteDeleteAsync executes immediately! and does not use implicit transactions.
             await context.RolloverWorkflowCandidates
-                .Where(x => !EF.Constant(incomingCandidateIds.Contains(x.RolloverCandidatesId)))
+                .Where(x => !EF.Constant(incomingCandidateIds).Contains(x.RolloverCandidatesId))
                 .ExecuteDeleteAsync(cancellationToken);
 
             context.RolloverWorkflowRuns.Add(workflowRun);

--- a/src/SFA.DAS.AODP.Data/Repositories/Rollover/RolloverRepository.cs
+++ b/src/SFA.DAS.AODP.Data/Repositories/Rollover/RolloverRepository.cs
@@ -199,7 +199,7 @@ public class RolloverRepository(IApplicationDbContext context) : IRolloverReposi
         try
         {
             await context.RolloverWorkflowCandidates
-                .Where(x => incomingCandidateIds.Contains(x.RolloverCandidatesId))
+                .Where(x => !incomingCandidateIds.Contains(x.RolloverCandidatesId))
                 .ExecuteDeleteAsync(cancellationToken);
 
             context.RolloverWorkflowRuns.Add(workflowRun);

--- a/src/SFA.DAS.AODP.Data/SFA.DAS.AODP.Data.csproj
+++ b/src/SFA.DAS.AODP.Data/SFA.DAS.AODP.Data.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
+	<PackageReference Include="EFCore.BulkExtensions.SqlServer" Version="10.0.1" />
 	<PackageReference Include="Lucene.Net" Version="4.8.0-beta00017" />
 	<PackageReference Include="Lucene.Net.Analysis.Common" Version="4.8.0-beta00017" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.8" />

--- a/src/SFA.DAS.AODP.Database/SFA.DAS.AODP.Database.sqlproj
+++ b/src/SFA.DAS.AODP.Database/SFA.DAS.AODP.Database.sqlproj
@@ -180,6 +180,7 @@
     <Build Include="Tables\RegulatedQaaQualification.sql" />
     <Build Include="Tables\RegulatedQaaQualificationHistory.sql" />
     <Build Include="Tables\Rollover\RolloverCandidates.sql" />
+    <Build Include="Tables\Rollover\FundingExtensionStaging.sql" />
     <Build Include="Tables\Rollover\RolloverDecisionRun.sql" />
     <Build Include="Tables\Rollover\RolloverWorkflowCandidate.sql" />
     <Build Include="Tables\Rollover\RolloverWorkflowRun.sql" />

--- a/src/SFA.DAS.AODP.Database/Tables/Rollover/FundingExtensionStaging.sql
+++ b/src/SFA.DAS.AODP.Database/Tables/Rollover/FundingExtensionStaging.sql
@@ -1,0 +1,23 @@
+CREATE TABLE [dbo].[FundingExtensionStaging]
+(
+    [OperationId]               UNIQUEIDENTIFIER NOT NULL,
+    [RolloverCandidateId]       UNIQUEIDENTIFIER NOT NULL,
+    [QualificationFundingId]    UNIQUEIDENTIFIER NULL,
+    [RolloverStatus]            NVARCHAR(255) NOT NULL,
+    [ExclusionReason]           NVARCHAR(255) NULL,
+    [NewFundingEndDate]         DATETIME2(7) NULL,
+    [FundingEndDate]            DATE NULL,
+    [FundingComments]           NVARCHAR(MAX) NULL,
+    [CreatedAt]                 DATETIME2(7) NOT NULL,
+    CONSTRAINT [PK_FundingExtensionStaging]
+        PRIMARY KEY CLUSTERED ([OperationId], [RolloverCandidateId]),
+    CONSTRAINT [FK_FundingExtensionStaging_RolloverCandidates]
+        FOREIGN KEY ([RolloverCandidateId]) REFERENCES [dbo].[RolloverCandidates]([Id]),
+    CONSTRAINT [FK_FundingExtensionStaging_QualificationFundings]
+        FOREIGN KEY ([QualificationFundingId]) REFERENCES [funded].[QualificationFundings]([Id])
+);
+
+GO
+CREATE NONCLUSTERED INDEX [IX_FundingExtensionStaging_QualificationFundingId]
+    ON [dbo].[FundingExtensionStaging]([OperationId], [QualificationFundingId])
+    WHERE [QualificationFundingId] IS NOT NULL;

--- a/src/SFA.DAS.AODP.Database/Tables/Rollover/RolloverWorkflowCandidate.sql
+++ b/src/SFA.DAS.AODP.Database/Tables/Rollover/RolloverWorkflowCandidate.sql
@@ -24,5 +24,9 @@ CREATE NONCLUSTERED INDEX [IX_WorkflowCandidate_Run_PassP1]
     ON [dbo].[RolloverWorkflowCandidate]([RolloverWorkflowRunId] ASC, [PassP1] ASC);
 
 GO
+CREATE NONCLUSTERED INDEX [IX_WorkflowCandidate_RolloverCandidatesId]
+    ON [dbo].[RolloverWorkflowCandidate]([RolloverCandidatesId] ASC);
+
+GO
 CREATE UNIQUE NONCLUSTERED INDEX [UX_WorkflowCandidate_Run_NaturalKey]
     ON [dbo].[RolloverWorkflowCandidate]([RolloverWorkflowRunId] ASC, [QualificationVersionId] ASC, [FundingOfferId] ASC, [AcademicYear] ASC, [RolloverRound] ASC);

--- a/src/SFA.DAS.AODP.sln
+++ b/src/SFA.DAS.AODP.sln
@@ -29,6 +29,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
 		Directory.Build.props = Directory.Build.props
+		rollover-performance-testing.md = rollover-performance-testing.md
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SFA.DAS.AODP.Testing", "SFA.DAS.AODP.Testing\SFA.DAS.AODP.Testing.csproj", "{BAA6471B-96A7-4CA3-B57F-F177F6A5D2E8}"

--- a/src/rollover-performance-testing.md
+++ b/src/rollover-performance-testing.md
@@ -1,0 +1,63 @@
+# Rollover performance testing
+
+## Why I looked at this
+
+The funding extension submission can contain around 13,000 records and we have a 30 second request timeout to work within. The two main problems I was seeing were the size of the request going through Azure and the amount of time spent loading and saving the data.
+
+The qualification funding load was taking around 17 seconds in the test environment, and the original tracked EF save was also doing a lot of work in one go. I wanted to get the database work down without adding hand-written SQL, stored procedures or relying on temp table permissions.
+
+## What has changed
+
+For the request size issue, the rollover data is now sent as a JSON file inside multipart form data rather than thousands of separate form fields. This gets around the ASP.NET `MaxModelBindingCollectionSize` problem and also avoids the multipart section issue we were hitting through Azure.
+
+For the processing itself:
+
+- The candidate inputs and qualification fundings are put into dictionaries before applying updates. This avoids repeatedly scanning the full collection for every candidate.
+- Qualification fundings are loaded using the qualification version IDs and then matched against the full `(QualificationVersionId, FundingOfferId)` key in memory. The query is no tracking because the persistence step does not use tracked EF updates.
+- Candidate and funding changes are written to a permanent `FundingExtensionStaging` table using a bulk insert.
+- EF Core `ExecuteUpdateAsync` applies the staged candidate and funding changes as set based updates.
+- Discussion history is bulk inserted and workflow candidates are removed using `ExecuteDeleteAsync`.
+- Everything is kept in one transaction. The staging rows are removed after a successful run and rollback plus a defensive cleanup handles failures.
+- Timing logs have been added around the candidate load, funding load, lookup creation, history creation, persistence stages and the overall request.
+
+## Approaches I compared
+
+I looked at a few different ways of doing this:
+
+- Normal tracked EF and `SaveChangesAsync`. This is the simplest, but it gets expensive when EF has to track and save tens of thousands of candidate, funding and history entities.
+- Direct EF Core Bulk Extensions updates. This was quick locally, but the update path uses temp-table/MERGE behaviour on SQL Server and that caused permission problems in Azure.
+- A JSON/set based SQL approach. This was the quickest benchmark, but I did not want to introduce hand-written SQL or a stored proc just for this process.
+- A temp staging table. This also performed well but needs temp table permissions, which the application does not have and I did not want to add.
+- A permanent staging table with bulk insert and EF Core set based updates. This is the approach used now. It keeps most of the speed of the bulk option without hand-written update SQL or temp table permissions.
+- An async upload, blob scan and status poller. This is still the safer long-term option if the full request cannot reliably stay under 30 seconds, especially as Defender for Storage means the blob has to be scanned before processing. It is a bigger change, so I have not added it as part of this work.
+
+## Final benchmark results
+
+These were run with BenchmarkDotNet on .NET 10 using an in-memory SQLite relational database. The 13,000 record figures are the useful ones for the current problem.
+
+| Area | Original approach | Changed/tested approach | Original time | New time | Improvement | Original allocation | New allocation |
+| --- | --- | --- | ---: | ---: | ---: | ---: | ---: |
+| Discussion history creation | `FirstOrDefault` scan for each candidate | Funding dictionary lookup | 254.49 ms | 9.80 ms | 26x faster / 96% less time | 5.30 MB | 5.00 MB |
+| Candidate graph loading | Full graph with `Include` | Lightweight tracked projection | 794.78 ms | 189.56 ms | 4.2x faster / 76% less time | 120.17 MB | 24.98 MB |
+| Qualification funding load | Concatenated composite key | Indexed composite-key join | 1,662.99 ms | 63.15 ms | 26x faster / 96% less time | 19.35 MB | 9.92 MB |
+| Persistence | Tracked EF and `SaveChangesAsync` | Permanent staging plus EF set updates | 6,686.13 ms | 246.51 ms | 27x faster / 96% less time | 370.48 MB | 41.99 MB |
+
+The permanent staging approach was also slightly quicker than the direct Bulk Extensions update in this run: 246.51 ms compared with 253.27 ms. It allocated around 42 MB compared with around 57 MB.
+
+The quickest persistence result was 134.07 ms using hand-written set based SQL, but that option was deliberately not taken. Saving another roughly 112 ms is not worth bringing manual SQL and its maintenance overhead into this flow.
+
+## What the combined numbers mean
+
+Using the approaches that are actually in the code now, the local benchmark estimate comes down from roughly 9.40 seconds to around 3.90 seconds across candidate loading, funding loading, history creation and persistence. That is around 5.5 seconds saved, or about 59% overall.
+
+The biggest confirmed gain is the save itself. The benchmark reduced that from 6.69 seconds to 247 ms and cut managed allocations by around 89%. The dictionary history lookup is also worth keeping, although on its own it only saves around a quarter of a second at 13,000 records.
+
+The candidate projection and indexed composite-key join show what is possible, but they are not both implemented in the final flow. The candidate load still needs tracked entities because they are used to apply the domain updates. The funding query currently uses the smaller, low-risk version-ID query plus an in-memory key lookup.
+
+There is an important caveat with the funding query. In the local benchmark, the current no-tracking version-ID approach took 2.85 seconds at 13,000 candidates because it loaded all four funding offers for each qualification version. The old concatenated query took 1.66 seconds locally. In Azure the old query was observed at around 17 seconds, most likely because concatenating columns prevents the useful index from being used in the same way. This means the local benchmark is good for comparing allocations and code shape, but it cannot promise the Azure SQL timing. The new Application Insights logs are the actual source of truth after deployment.
+
+## What I expect in Azure
+
+The funding load is still the main thing to watch. If that stays anywhere near the 17 seconds already seen, there should still be enough headroom from the persistence saving to improve the chance of staying below 30 seconds, but it is not guaranteed. I will use the stage timing logs in Application Insights to check the real candidate load, funding load, staging insert, candidate update, funding update, history insert and transaction total.
+
+If the whole request is still getting close to 30 seconds after deployment, I would stop trying to squeeze more work into the HTTP request and move the submit flow to the async blob upload and status polling approach.


### PR DESCRIPTION
[AWARD-1240]

- Add in workaround code for now to allow for bypassing the request size limit in the WAF by sending the large rollover candidate data as a multipart form data json payload request allowing it to look like a file upload to the WAF 
- Added in new methods in ApiClient to allow for sending a json payload that looks like a file upload and sending to the next layer as a multipart form data
- Temporary workaround whilst a more asynchronous file processing approach is developed
- Also optimised the performance of the database operations to ensure it stays within the 30 second request timeout limit, this included moving to more set based operations and bulk insertion/update commands

[AWARD-1240]: https://skillsfundingagency.atlassian.net/browse/AWARD-1240?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ